### PR TITLE
Detect host OS and set additional dependencies accordingly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ if HAVE_RAGEL
 	$(AM_V_GEN)$(RAGEL) $(RAGELFLAGS) -C $< -o $@
 endif
 
-libreadstat_la_LIBADD = -llzma -lz -liconv
+libreadstat_la_LIBADD = -llzma -lz @EXTRA_LIBS@
 libreadstat_la_LDFLAGS =
 
 include_HEADERS = src/readstat.h
@@ -56,4 +56,3 @@ endif
 
 install-exec-hook:
 	@(cd $(DESTDIR)$(libdir) && $(RM) $(lib_LTLIBRARIES))
-

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ readstat_SOURCES = \
 	src/bin/modules/mod_csv.c \
 	src/bin/modules/mod_readstat.c
 
-readstat_LDADD = -lreadstat
+readstat_LDADD = libreadstat.la
 readstat_CFLAGS =
 
 if HAVE_XLSXWRITER

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,13 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 LT_INIT([disable-static])
 AC_PROG_CC
+AC_CANONICAL_HOST
+AS_CASE([$host],
+	[*darwin*], [EXTRA_LIBS="-liconv"],
+	[*linux*], [EXTRA_LIBS="-lm"],
+	[EXTRA_LIBS=""]
+)
+AC_SUBST([EXTRA_LIBS])
 AC_ARG_VAR([RAGEL], [Ragel generator command])
 AC_ARG_VAR([RAGELFLAGS], [Ragel generator flags])
 AC_PATH_PROG([RAGEL], [ragel], [true])
@@ -10,3 +17,15 @@ AM_CONDITIONAL([HAVE_RAGEL], test "$RAGEL" != "true")
 AC_CHECK_LIB([xlsxwriter], [workbook_new])
 AM_CONDITIONAL([HAVE_XLSXWRITER], test "$ac_cv_lib_xlsxwriter_workbook_new" = yes)
 AC_OUTPUT([Makefile])
+
+AC_MSG_RESULT([
+Configuration:
+
+C compiler: $CC
+CFLAGS: $CFLAGS
+
+Host: $host
+Host specific libs: $EXTRA_LIBS
+
+Ragel: $RAGEL
+Ragel flags: $RAGELFLAGS])


### PR DESCRIPTION
It seems that the additional dependencies for libreadstat.so vary across platforms, i.e on Mac you need -liconv while on Linux -lm is required (for pow()).

This commit adds the detection of canonical host and then sets EXTRA_LIBS accordingly.

Also added printing the configuration results at end.