### PR TITLE
Windows, msys2 and appveyor

### DIFF
--- a/.appveyor/build_script.bat
+++ b/.appveyor/build_script.bat
@@ -1,0 +1,12 @@
+set PATH=C:\msys64\usr\bin;%PATH%
+set PATH=C:\msys64\mingw64\bin;%PATH%
+
+set CC=x86_64-w64-mingw32-gcc
+
+REM echo useful info
+bash --login -c "$CC -v"
+
+REM appveyor msys configure workaround "exec 0</dev/null"
+bash --login -c "cd `cygpath '%CD%'`; exec 0</dev/null; ./autogen.sh"
+bash --login -c "cd `cygpath '%CD%'`; exec 0</dev/null; ./configure"
+bash --login -c "cd `cygpath '%CD%'`; make"

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,0 +1,1 @@
+C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-cmake"

--- a/.appveyor/install.bat
+++ b/.appveyor/install.bat
@@ -1,1 +1,2 @@
 C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-cmake"
+C:\msys64\usr\bin\bash --login -c "pacman -S --noconfirm mingw-w64-x86_64-zlib"

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ endif
 
 libreadstat_la_CFLAGS = -Wall
 libreadstat_la_LIBADD = -llzma -lz @EXTRA_LIBS@
-libreadstat_la_LDFLAGS =
+libreadstat_la_LDFLAGS = -no-undefined
 
 include_HEADERS = src/readstat.h
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Bootstrap autotools by running ./autogen.sh and then proceed as usual:
     make
     sudo make install
 
+Windows specific notes
+--
+
+You need to install and configure an msys2 environment to compile ReadStat.
+
+First, download and install msys2 from [here](https://msys2.github.io/). Make ure you update your initial msys2 installation as described on tht page.
+
+Second, install a number of additional packages at the msys2 command line:
+
+    pacman -S autoconf automake libtool mingw-w64-x86_64-toolchain ingw-w64-x86_64-cmake mingw-w64-x86_64-libiconv
+
+Finally, start a MINGW command line (not the msys2 prompt!) and follow the eneral install instructions for this package.
+
 Command-line Usage
 ==
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 0.1.{build}
+
+os: Windows Server 2012 R2
+
+platform: x64
+
+branches:
+  only:
+    - master
+
+skip_tags: true
+
+install:
+  - .appveyor\install.bat
+
+build_script:
+  - .appveyor\build_script.bat

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,13 @@
 AC_INIT([readstat], [20160511])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
-LT_INIT([disable-static])
+LT_INIT([disable-static, win32-dll])
 AC_PROG_CC
 AC_CANONICAL_HOST
 AS_CASE([$host],
 	[*darwin*], [EXTRA_LIBS="-liconv"],
 	[*linux*], [EXTRA_LIBS="-lm"],
+	[*mingw64],  [EXTRA_LIBS="-liconv"],
 	[EXTRA_LIBS=""]
 )
 AC_SUBST([EXTRA_LIBS])


### PR DESCRIPTION
This is work in progress, so don't merge. This is my attempt to get things compiling and working on Windows. So far things don't work and I'm hoping I can get some help via this PR.

The build output I currently get is [this](https://ci.appveyor.com/project/davidanthoff/readstat/build/0.1.26).

As far as I can tell there are two problems:
1) something with the ``-lz`` library. Probably that just requires another dependency to be installed via pacman
2) It seems to me that things start to go wrong with various calls to ``dprintf``. I'm not sure whether those calls could be replaced with something else, or whether I'm just missing another dependency.

My real goal is to get WizardMac/DataRead.jl#12 going. For a really stable solution we would probably have to get cross-compiling on the SUSE build infrastructure going, but for starters it seemed helpful if one can compile things locally with msys2.

Please also see my comments on specific changes that I made, they need careful review, I am not really familiar with these tools :)
