### PR TITLE
Link iconv on all mingw platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CANONICAL_HOST
 AS_CASE([$host],
 	[*darwin*], [EXTRA_LIBS="-liconv"],
 	[*linux*], [EXTRA_LIBS="-lm"],
-	[*mingw64],  [EXTRA_LIBS="-liconv"],
+	[*mingw*],  [EXTRA_LIBS="-liconv"],
 	[EXTRA_LIBS=""]
 )
 AC_SUBST([EXTRA_LIBS])


### PR DESCRIPTION
This is needed to get the opensuse builds running.