### PR TITLE
Fixes for cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ endif
 
 libreadstat_la_CFLAGS = -Wall
 libreadstat_la_LIBADD = -llzma -lz @EXTRA_LIBS@
-libreadstat_la_LDFLAGS = -no-undefined
+libreadstat_la_LDFLAGS = @EXTRA_LDFLAGS@
 
 include_HEADERS = src/readstat.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,22 +1,28 @@
 AC_INIT([readstat], [20160511])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
-LT_INIT([disable-static, win32-dll])
+
+LT_INIT([disable-static])
+
 AC_PROG_CC
+
 AC_CANONICAL_HOST
 AS_CASE([$host],
-	[*darwin*], [EXTRA_LIBS="-liconv"],
-	[*linux*], [EXTRA_LIBS="-lm"],
-	[*mingw*],  [EXTRA_LIBS="-liconv"],
-	[EXTRA_LIBS=""]
+	[*darwin*], [EXTRA_LIBS="-liconv" EXTRA_LDFLAGS=""],
+	[*linux*], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS=""],
+	[*mingw*|*cygwin*], [EXTRA_LIBS="-liconv -lm" EXTRA_LDFLAGS="-no-undefined"],
+	[EXTRA_LIBS="" EXTRA_LDFLAGS=""]
 )
 AC_SUBST([EXTRA_LIBS])
+AC_SUBST([EXTRA_LDFLAGS])
+
 AC_ARG_VAR([RAGEL], [Ragel generator command])
 AC_ARG_VAR([RAGELFLAGS], [Ragel generator flags])
 AC_PATH_PROG([RAGEL], [ragel], [true])
 AM_CONDITIONAL([HAVE_RAGEL], test "$RAGEL" != "true")
 AC_CHECK_LIB([xlsxwriter], [workbook_new], [true], [false])
 AM_CONDITIONAL([HAVE_XLSXWRITER], test "$ac_cv_lib_xlsxwriter_workbook_new" = yes)
+
 AC_OUTPUT([Makefile])
 
 AC_MSG_RESULT([
@@ -26,7 +32,8 @@ C compiler: $CC
 CFLAGS: $CFLAGS
 
 Host: $host
-Host specific libs: $EXTRA_LIBS
+Extra libs: $EXTRA_LIBS
+Extra ld flags: $EXTRA_LDFLAGS
 
 Ragel: $RAGEL
 Ragel flags: $RAGELFLAGS])

--- a/src/readstat_io_unistd.c
+++ b/src/readstat_io_unistd.c
@@ -14,7 +14,7 @@
 #define UNISTD_OPEN_OPTIONS O_RDONLY
 #endif
 
-#if defined _WIN32 || defined __CYGWIN__ || defined _AIX
+#if defined _WIN32 || defined _AIX
 #define lseek lseek64
 #endif
 


### PR DESCRIPTION
Here's a couple of fixes for building on cygwin. I get linking errors due to lseek defined as lseek64 and missing libiconv dependency. This commit should take care of both. In addition, I've changed the -no-undefined flag to linker to be passed on mingw or cygwin only -- it doesn't do anything on other platforms.