### PR TITLE
Autotools improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,17 @@ if HAVE_RAGEL
 endif
 
 libreadstat_la_CFLAGS = -Wall
-libreadstat_la_LIBADD = -llzma -lz @EXTRA_LIBS@
+
+libreadstat_la_LIBADD = -llzma -lz
+
+if HAVE_ICONV
+libreadstat_la_LIBADD += -liconv
+endif
+
+if HAVE_MATH
+libreadstat_la_LIBADD += -lm
+endif
+
 libreadstat_la_LDFLAGS = -version-info 0:0:0 @EXTRA_LDFLAGS@
 
 include_HEADERS = src/readstat.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ endif
 
 libreadstat_la_CFLAGS = -Wall
 libreadstat_la_LIBADD = -llzma -lz @EXTRA_LIBS@
-libreadstat_la_LDFLAGS = @EXTRA_LDFLAGS@
+libreadstat_la_LDFLAGS = -version-info 0:0:0 @EXTRA_LDFLAGS@
 
 include_HEADERS = src/readstat.h
 
@@ -89,6 +89,8 @@ readstat_SOURCES += src/bin/modules/mod_xlsx.c
 readstat_LDADD += -lxlsxwriter
 readstat_CFLAGS += -DHAVE_XLSXWRITER=1
 endif
+
+EXTRA_DIST = LICENSE README.md
 
 check_PROGRAMS = \
 	test_readstat

--- a/configure.ac
+++ b/configure.ac
@@ -6,13 +6,13 @@ LT_INIT([disable-static])
 
 AC_PROG_CC
 
-AC_ARG_ENABLE([static-iconv], AS_HELP_STRING([--enable-static-iconv], [Link iconv statically]), [static_iconv=yes], [static_iconv=no])
+AC_ARG_ENABLE([static-iconv], AS_HELP_STRING([--enable-static-iconv], [Link iconv statically]))
 
 AC_CANONICAL_HOST
 AS_CASE([$host],
 	[*darwin*], [EXTRA_LIBS="-liconv" EXTRA_LDFLAGS=""],
 	[*linux*], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS=""],
-	[*mingw*|*cygwin*], [AS_IF([test "x$static_iconv" = "xyes"], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS="-Wl,-Bstatic,-liconv -no-undefined"], [EXTRA_LIBS="-liconv -lm" EXTRA_LDFLAGS="-no-undefined"])],
+	[*mingw*|*cygwin*], [AS_IF([test "x$enable_static_iconv" = "xyes"], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS="-Wl,-Bstatic,-liconv -no-undefined"], [EXTRA_LIBS="-liconv -lm" EXTRA_LDFLAGS="-no-undefined"])],
 	[EXTRA_LIBS="" EXTRA_LDFLAGS=""]
 )
 AC_SUBST([EXTRA_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -10,22 +10,35 @@ AC_PROG_CC
 
 AC_ARG_ENABLE([static-iconv], AS_HELP_STRING([--enable-static-iconv], [Link iconv statically]))
 
+AC_CHECK_LIB([iconv], [iconv_open], [true], [false])
+AM_CONDITIONAL([HAVE_ICONV], test x"$ac_cv_lib_iconv_iconv_open" = "xyes")
+
+AC_CHECK_LIB([m], [pow], [true], [false])
+AM_CONDITIONAL([HAVE_MATH], test x"$ac_cv_lib_m_pow" = "xyes")
+
+AC_CHECK_LIB([lzma], [lzma_stream_decoder], [true], [AC_MSG_ERROR([lzma not found])])
+AM_CONDITIONAL([HAVE_LZMA], test x"$ac_cv_lib_lzma_lzma_stream_decoder" = "xyes")
+
+AC_CHECK_LIB([z], [zlibVersion], [true], [AC_MSG_ERROR([zlib not found])])
+AM_CONDITIONAL([HAVE_ZLIB], test x"$ac_cv_lib_z_zlibVersion" = "xyes")
+
+AC_CHECK_LIB([xlsxwriter], [workbook_new], [true], [false])
+AM_CONDITIONAL([HAVE_XLSXWRITER], test x"$ac_cv_lib_xlsxwriter_workbook_new" = "xyes")
+
 AC_CANONICAL_HOST
 AS_CASE([$host],
-	[*darwin*], [EXTRA_LIBS="-liconv" EXTRA_LDFLAGS=""],
-	[*linux*], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS=""],
-	[*mingw*|*cygwin*], [AS_IF([test "x$enable_static_iconv" = "xyes"], [EXTRA_LIBS="-lm" EXTRA_LDFLAGS="-Wl,-Bstatic,-liconv -no-undefined"], [EXTRA_LIBS="-liconv -lm" EXTRA_LDFLAGS="-no-undefined"])],
-	[EXTRA_LIBS="" EXTRA_LDFLAGS=""]
+	[*darwin*], [EXTRA_LDFLAGS=""],
+	[*linux*], [EXTRA_LDFLAGS=""],
+	[*mingw*|*cygwin*], [AS_IF([test "x$enable_static_iconv" = "xyes"], [EXTRA_LDFLAGS="-Wl,-Bstatic,-liconv -no-undefined"], [EXTRA_LDFLAGS="-no-undefined"])],
+	[EXTRA_LDFLAGS=""]
 )
-AC_SUBST([EXTRA_LIBS])
 AC_SUBST([EXTRA_LDFLAGS])
 
 AC_ARG_VAR([RAGEL], [Ragel generator command])
 AC_ARG_VAR([RAGELFLAGS], [Ragel generator flags])
+
 AC_PATH_PROG([RAGEL], [ragel], [true])
 AM_CONDITIONAL([HAVE_RAGEL], test "$RAGEL" != "true")
-AC_CHECK_LIB([xlsxwriter], [workbook_new], [true], [false])
-AM_CONDITIONAL([HAVE_XLSXWRITER], test "$ac_cv_lib_xlsxwriter_workbook_new" = yes)
 
 AC_OUTPUT([Makefile])
 
@@ -36,7 +49,6 @@ C compiler: $CC
 CFLAGS: $CFLAGS
 
 Host: $host
-Extra libs: $EXTRA_LIBS
 Extra ld flags: $EXTRA_LDFLAGS
 
 Ragel: $RAGEL

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,6 @@
-AC_INIT([readstat], [0.1.1])
+AC_INIT([ReadStat], [0.1.1], [emmiller@gmail.com], [ReadStat], [https://github.com/WizardMac/ReadStat])
+AC_CONFIG_HEADER([config.h])
+
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 

--- a/src/bin/readstat.c
+++ b/src/bin/readstat.c
@@ -11,11 +11,11 @@
 #include "modules/mod_readstat.h"
 #include "modules/mod_csv.h"
 
+#include "config.h"
+
 #if HAVE_XLSXWRITER
 #include "modules/mod_xlsx.h"
 #endif
-
-#define RS_VERSION_STRING  "1.0-prerelease"
 
 #define RS_FORMAT_UNKNOWN       0x00
 #define RS_FORMAT_DTA           0x01
@@ -171,7 +171,7 @@ readstat_error_t parse_file(readstat_parser_t *parser, const char *input_filenam
 }
 
 static void print_version() {
-    fprintf(stderr, "ReadStat version " RS_VERSION_STRING "\n");
+    fprintf(stderr, PACKAGE_NAME " version " PACKAGE_VERSION "\n");
 }
 
 static void print_usage(const char *cmd) {


### PR DESCRIPTION
Here's a bunch of commits to hopefully simplify the autotools process a bit. The idea is that rather than hardcoding libraries for each host we just check the availability of optional ones and explicitly check the required ones (lzma, zlib). Also, the package version (+ other info, e.g. name and url) go into config.h now. Those defines could be used whenever printing version information so I've taken them into use for the cli tool.
