### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_SUBST([SANITIZERS])
 AC_CANONICAL_HOST
 AS_CASE([$host],
 	[*darwin*], [EXTRA_LIBS="-liconv"],
-	[*linux*], [EXTRA_LIBS="-lm"],
+	[*linux*|*bsd*], [EXTRA_LIBS="-lm"],
 	[*mingw*|*cygwin*], [AS_IF([test "x$static_iconv" = "xyes"],
                                [EXTRA_LIBS="-lm"],
                                [EXTRA_LIBS="-liconv -lm"])],


### PR DESCRIPTION
Currently building on FreeBSD fails since libm is required but isn't getting linked, so this adds `-lm` in the same manner as is done on Linux. With this change, compilation succeeds and all tests pass with `gmake check`.