### PR TITLE
fixed skipping columns for XPT files

### DIFF
--- a/src/sas/readstat_xport_read.c
+++ b/src/sas/readstat_xport_read.c
@@ -562,9 +562,11 @@ static readstat_error_t xport_process_row(xport_ctx_t *ctx, const char *row, siz
         }
         pos += variable->storage_width;
 
-        if (ctx->handle.value(ctx->parsed_row_count, variable, value, ctx->user_ctx) != READSTAT_HANDLER_OK) {
-            retval = READSTAT_ERROR_USER_ABORT;
-            goto cleanup;
+        if (ctx->handle.value && !ctx->variables[i]->skip) {
+            if (ctx->handle.value(ctx->parsed_row_count, variable, value, ctx->user_ctx) != READSTAT_HANDLER_OK) {
+                retval = READSTAT_ERROR_USER_ABORT;
+                goto cleanup;
+            }
         }
     }
 


### PR DESCRIPTION
When skipping columns (returning READSTAT_HANDLER_SKIP_VARIABLE from my variable handler function for certain variables) and then recovering the index after skipping with readstat_variable_get_index_after_skipping from my value handler function, the index after skipping does not look right in the case of XPT files.
It seems to me that in the function xport_process_row in readstat_xport_read.c this case is not handled.
I replaced lines 565-568 by this (copied from readstat_por_read.c line 629), and it seems to solve the issue