### PR TITLE
Add API for row skipping

### DIFF
--- a/src/readstat.h
+++ b/src/readstat.h
@@ -341,6 +341,7 @@ typedef struct readstat_parser_s {
     const char             *input_encoding;
     const char             *output_encoding;
     long                    row_limit;
+    long                    rows_skip;
 } readstat_parser_t;
 
 readstat_parser_t *readstat_parser_init(void);
@@ -372,6 +373,7 @@ readstat_error_t readstat_set_file_character_encoding(readstat_parser_t *parser,
 readstat_error_t readstat_set_handler_character_encoding(readstat_parser_t *parser, const char *encoding);
 
 readstat_error_t readstat_set_row_limit(readstat_parser_t *parser, long row_limit);
+readstat_error_t readstat_set_rows_skip(readstat_parser_t *parser, long rows_skip);
 
 /* Parse binary / portable files */
 readstat_error_t readstat_parse_dta(readstat_parser_t *parser, const char *path, void *user_ctx);

--- a/src/readstat.h
+++ b/src/readstat.h
@@ -341,7 +341,7 @@ typedef struct readstat_parser_s {
     const char             *input_encoding;
     const char             *output_encoding;
     long                    row_limit;
-    long                    rows_skip;
+    long                    row_offset;
 } readstat_parser_t;
 
 readstat_parser_t *readstat_parser_init(void);
@@ -373,7 +373,7 @@ readstat_error_t readstat_set_file_character_encoding(readstat_parser_t *parser,
 readstat_error_t readstat_set_handler_character_encoding(readstat_parser_t *parser, const char *encoding);
 
 readstat_error_t readstat_set_row_limit(readstat_parser_t *parser, long row_limit);
-readstat_error_t readstat_set_rows_skip(readstat_parser_t *parser, long rows_skip);
+readstat_error_t readstat_set_row_offset(readstat_parser_t *parser, long row_offset);
 
 /* Parse binary / portable files */
 readstat_error_t readstat_parse_dta(readstat_parser_t *parser, const char *path, void *user_ctx);

--- a/src/readstat_parser.c
+++ b/src/readstat_parser.c
@@ -114,3 +114,8 @@ readstat_error_t readstat_set_row_limit(readstat_parser_t *parser, long row_limi
     parser->row_limit = row_limit;
     return READSTAT_OK;
 }
+
+readstat_error_t readstat_set_rows_skip(readstat_parser_t *parser, long rows_skip) {
+    parser->rows_skip = rows_skip;
+    return READSTAT_OK;
+}

--- a/src/readstat_parser.c
+++ b/src/readstat_parser.c
@@ -115,7 +115,7 @@ readstat_error_t readstat_set_row_limit(readstat_parser_t *parser, long row_limi
     return READSTAT_OK;
 }
 
-readstat_error_t readstat_set_rows_skip(readstat_parser_t *parser, long rows_skip) {
-    parser->rows_skip = rows_skip;
+readstat_error_t readstat_set_row_offset(readstat_parser_t *parser, long row_offset) {
+    parser->row_offset = row_offset;
     return READSTAT_OK;
 }

--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -49,7 +49,7 @@ typedef struct sas7bdat_ctx_s {
     uint32_t        parsed_row_count;
     uint32_t        column_count;
     uint32_t        row_limit;
-    uint32_t        rows_skip;
+    uint32_t        row_offset;
 
     uint64_t        header_size;
     uint64_t        page_count;
@@ -234,8 +234,8 @@ static readstat_error_t sas7bdat_parse_row_size_subheader(const char *subheader,
 
     ctx->page_row_count = page_row_count;
     uint64_t total_row_count_after_skipping = total_row_count;
-    if (total_row_count > ctx->rows_skip) {
-        total_row_count_after_skipping -= ctx->rows_skip;
+    if (total_row_count > ctx->row_offset) {
+        total_row_count_after_skipping -= ctx->row_offset;
     } else {
         total_row_count_after_skipping = 0;
     }
@@ -431,8 +431,8 @@ cleanup:
 static readstat_error_t sas7bdat_parse_single_row(const char *data, sas7bdat_ctx_t *ctx) {
     if (ctx->parsed_row_count == ctx->row_limit)
         return READSTAT_OK;
-    if (ctx->rows_skip) {
-        ctx->rows_skip--;
+    if (ctx->row_offset) {
+        ctx->row_offset--;
         return READSTAT_OK;
     }
 
@@ -1053,8 +1053,8 @@ readstat_error_t readstat_parse_sas7bdat(readstat_parser_t *parser, const char *
     ctx->user_ctx = user_ctx;
     ctx->io = parser->io;
     ctx->row_limit = parser->row_limit;
-    if (parser->rows_skip > 0)
-        ctx->rows_skip = parser->rows_skip;
+    if (parser->row_offset > 0)
+        ctx->row_offset = parser->row_offset;
 
     if (io->open(path, io->io_ctx) == -1) {
         retval = READSTAT_ERROR_OPEN;

--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -238,6 +238,7 @@ static readstat_error_t sas7bdat_parse_row_size_subheader(const char *subheader,
         total_row_count_after_skipping -= ctx->row_offset;
     } else {
         total_row_count_after_skipping = 0;
+        ctx->row_offset = total_row_count;
     }
     if (ctx->row_limit == 0 || total_row_count_after_skipping < ctx->row_limit)
         ctx->row_limit = total_row_count_after_skipping;

--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -49,6 +49,7 @@ typedef struct sas7bdat_ctx_s {
     uint32_t        parsed_row_count;
     uint32_t        column_count;
     uint32_t        row_limit;
+    uint32_t        rows_skip;
 
     uint64_t        header_size;
     uint64_t        page_count;
@@ -232,8 +233,14 @@ static readstat_error_t sas7bdat_parse_row_size_subheader(const char *subheader,
     }
 
     ctx->page_row_count = page_row_count;
-    if (ctx->row_limit == 0 || total_row_count < ctx->row_limit)
-        ctx->row_limit = total_row_count;
+    uint64_t total_row_count_after_skipping = total_row_count;
+    if (total_row_count > ctx->rows_skip) {
+        total_row_count_after_skipping -= ctx->rows_skip;
+    } else {
+        total_row_count_after_skipping = 0;
+    }
+    if (ctx->row_limit == 0 || total_row_count_after_skipping < ctx->row_limit)
+        ctx->row_limit = total_row_count_after_skipping;
 
 cleanup:
     return retval;
@@ -424,6 +431,10 @@ cleanup:
 static readstat_error_t sas7bdat_parse_single_row(const char *data, sas7bdat_ctx_t *ctx) {
     if (ctx->parsed_row_count == ctx->row_limit)
         return READSTAT_OK;
+    if (ctx->rows_skip) {
+        ctx->rows_skip--;
+        return READSTAT_OK;
+    }
 
     readstat_error_t retval = READSTAT_OK;
     int j;
@@ -1042,6 +1053,8 @@ readstat_error_t readstat_parse_sas7bdat(readstat_parser_t *parser, const char *
     ctx->user_ctx = user_ctx;
     ctx->io = parser->io;
     ctx->row_limit = parser->row_limit;
+    if (parser->rows_skip > 0)
+        ctx->rows_skip = parser->rows_skip;
 
     if (io->open(path, io->io_ctx) == -1) {
         retval = READSTAT_ERROR_OPEN;

--- a/src/sas/readstat_xport_read.c
+++ b/src/sas/readstat_xport_read.c
@@ -636,7 +636,7 @@ static readstat_error_t xport_read_data(xport_ctx_t *ctx) {
             if (retval != READSTAT_OK)
                 goto cleanup;
 
-            if (ctx->parsed_row_count == ctx->row_limit)
+            if (ctx->row_limit > 0 && ctx->parsed_row_count == ctx->row_limit)
                 goto cleanup;
 
             num_blank_rows--;
@@ -650,7 +650,7 @@ static readstat_error_t xport_read_data(xport_ctx_t *ctx) {
         if (retval != READSTAT_OK)
             goto cleanup;
 
-        if (ctx->parsed_row_count == ctx->row_limit)
+        if (ctx->row_limit > 0 && ctx->parsed_row_count == ctx->row_limit)
             break;
     }
 

--- a/src/sas/readstat_xport_read.c
+++ b/src/sas/readstat_xport_read.c
@@ -29,7 +29,7 @@ typedef struct xport_ctx_s {
     int            obs_count;
     int            var_count;
     int            row_limit;
-    int            rows_skip;
+    int            row_offset;
     size_t         row_length;
     int            parsed_row_count;
     char           file_label[40*4+1];
@@ -600,12 +600,12 @@ static readstat_error_t xport_read_data(xport_ctx_t *ctx) {
         goto cleanup;
     }
 
-    if (ctx->rows_skip) {
-        if (ctx->io->seek(ctx->row_length * ctx->rows_skip, READSTAT_SEEK_CUR, ctx->io->io_ctx) == -1) {
+    if (ctx->row_offset) {
+        if (ctx->io->seek(ctx->row_length * ctx->row_offset, READSTAT_SEEK_CUR, ctx->io->io_ctx) == -1) {
             retval = READSTAT_ERROR_SEEK;
             goto cleanup;
         }
-        ctx->rows_skip = 0;
+        ctx->row_offset = 0;
     }
 
     memset(blank_row, ' ', ctx->row_length);
@@ -676,8 +676,8 @@ readstat_error_t readstat_parse_xport(readstat_parser_t *parser, const char *pat
     ctx->user_ctx = user_ctx;
     ctx->io = io;
     ctx->row_limit = parser->row_limit;
-    if (parser->rows_skip > 0)
-        ctx->rows_skip = parser->rows_skip;
+    if (parser->row_offset > 0)
+        ctx->row_offset = parser->row_offset;
 
     if (io->open(path, io->io_ctx) == -1) {
         retval = READSTAT_ERROR_OPEN;

--- a/src/spss/readstat_por.h
+++ b/src/spss/readstat_por.h
@@ -25,6 +25,7 @@ typedef struct por_ctx_s {
     int            var_count;
     int            var_offset;
     int            row_limit;
+    int            rows_skip;
     readstat_variable_t **variables;
     spss_varinfo_t *varinfo;
     ck_hash_table_t *var_dict;

--- a/src/spss/readstat_por.h
+++ b/src/spss/readstat_por.h
@@ -25,7 +25,7 @@ typedef struct por_ctx_s {
     int            var_count;
     int            var_offset;
     int            row_limit;
-    int            rows_skip;
+    int            row_offset;
     readstat_variable_t **variables;
     spss_varinfo_t *varinfo;
     ck_hash_table_t *var_dict;

--- a/src/spss/readstat_por_read.c
+++ b/src/spss/readstat_por_read.c
@@ -627,7 +627,7 @@ static readstat_error_t read_por_file_data(por_ctx_t *ctx) {
                 }
                 value.is_system_missing = isnan(value.v.double_value);
             }
-            if (ctx->handle.value && !ctx->variables[i]->skip && !ctx->rows_skip) {
+            if (ctx->handle.value && !ctx->variables[i]->skip && !ctx->row_offset) {
                 if (ctx->handle.value(ctx->obs_count, ctx->variables[i], value, ctx->user_ctx) != READSTAT_HANDLER_OK) {
                     rs_retval = READSTAT_ERROR_USER_ABORT;
                     goto cleanup;
@@ -635,8 +635,8 @@ static readstat_error_t read_por_file_data(por_ctx_t *ctx) {
             }
 
         }
-        if (ctx->rows_skip) {
-            ctx->rows_skip--;
+        if (ctx->row_offset) {
+            ctx->row_offset--;
         } else {
             ctx->obs_count++;
         }
@@ -748,8 +748,8 @@ readstat_error_t readstat_parse_por(readstat_parser_t *parser, const char *path,
     ctx->user_ctx = user_ctx;
     ctx->io = io;
     ctx->row_limit = parser->row_limit;
-    if (parser->rows_skip > 0)
-        ctx->rows_skip = parser->rows_skip;
+    if (parser->row_offset > 0)
+        ctx->row_offset = parser->row_offset;
 
     if (parser->output_encoding) {
         if (strcmp(parser->output_encoding, "UTF-8") != 0)

--- a/src/spss/readstat_por_read.c
+++ b/src/spss/readstat_por_read.c
@@ -627,7 +627,7 @@ static readstat_error_t read_por_file_data(por_ctx_t *ctx) {
                 }
                 value.is_system_missing = isnan(value.v.double_value);
             }
-            if (ctx->handle.value && !ctx->variables[i]->skip) {
+            if (ctx->handle.value && !ctx->variables[i]->skip && !ctx->rows_skip) {
                 if (ctx->handle.value(ctx->obs_count, ctx->variables[i], value, ctx->user_ctx) != READSTAT_HANDLER_OK) {
                     rs_retval = READSTAT_ERROR_USER_ABORT;
                     goto cleanup;
@@ -635,12 +635,16 @@ static readstat_error_t read_por_file_data(por_ctx_t *ctx) {
             }
 
         }
-        ctx->obs_count++;
+        if (ctx->rows_skip) {
+            ctx->rows_skip--;
+        } else {
+            ctx->obs_count++;
+        }
 
         rs_retval = por_update_progress(ctx);
         if (rs_retval != READSTAT_OK)
             break;
-
+            
         if (ctx->obs_count == ctx->row_limit)
             break;
     }
@@ -744,6 +748,8 @@ readstat_error_t readstat_parse_por(readstat_parser_t *parser, const char *path,
     ctx->user_ctx = user_ctx;
     ctx->io = io;
     ctx->row_limit = parser->row_limit;
+    if (parser->rows_skip > 0)
+        ctx->rows_skip = parser->rows_skip;
 
     if (parser->output_encoding) {
         if (strcmp(parser->output_encoding, "UTF-8") != 0)

--- a/src/spss/readstat_por_read.c
+++ b/src/spss/readstat_por_read.c
@@ -645,7 +645,7 @@ static readstat_error_t read_por_file_data(por_ctx_t *ctx) {
         if (rs_retval != READSTAT_OK)
             break;
             
-        if (ctx->obs_count == ctx->row_limit)
+        if (ctx->row_limit > 0 && ctx->obs_count == ctx->row_limit)
             break;
     }
 cleanup:

--- a/src/spss/readstat_sav.h
+++ b/src/spss/readstat_sav.h
@@ -85,6 +85,7 @@ typedef struct sav_ctx_s {
     int            var_count;
     int            record_count;
     int            row_limit;
+    int            rows_skip;
     int            current_row;
     int            value_labels_count;
     int            fweight_index;

--- a/src/spss/readstat_sav.h
+++ b/src/spss/readstat_sav.h
@@ -85,7 +85,7 @@ typedef struct sav_ctx_s {
     int            var_count;
     int            record_count;
     int            row_limit;
-    int            rows_skip;
+    int            row_offset;
     int            current_row;
     int            value_labels_count;
     int            fweight_index;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -678,6 +678,11 @@ static readstat_error_t sav_read_dictionary_termination_record(sav_ctx_t *ctx) {
 }
 
 static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len, sav_ctx_t *ctx) {
+    if (ctx->rows_skip) {
+        ctx->rows_skip--;
+        return READSTAT_OK;
+    }
+
     readstat_error_t retval = READSTAT_OK;
     double fp_value;
     int offset = 0;
@@ -802,6 +807,14 @@ static readstat_error_t sav_read_uncompressed_data(sav_ctx_t *ctx,
     size_t buffer_len = ctx->var_offset * 8;
 
     buffer = readstat_malloc(buffer_len);
+
+    if (ctx->rows_skip) {
+        if (io->seek(buffer_len * ctx->rows_skip, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
+            retval = READSTAT_ERROR_SEEK;
+            goto done;
+        }
+        ctx->rows_skip = 0;
+    }
 
     while (ctx->row_limit == -1 || ctx->current_row < ctx->row_limit) {
         retval = sav_update_progress(ctx);
@@ -1569,11 +1582,14 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
     ctx->output_encoding = parser->output_encoding;
     ctx->user_ctx = user_ctx;
     ctx->file_size = file_size;
-    if (parser->row_limit > 0 && (parser->row_limit < ctx->record_count || ctx->record_count == -1)) {
+    if (parser->rows_skip > 0)
+        ctx->rows_skip = parser->rows_skip;
+    int record_count_after_skipping = ctx->record_count - ctx->rows_skip;
+    if (record_count_after_skipping < 0)
+        record_count_after_skipping = 0;
+    ctx->row_limit = record_count_after_skipping;
+    if (parser->row_limit > 0 && (parser->row_limit < record_count_after_skipping || ctx->record_count == -1)) 
         ctx->row_limit = parser->row_limit;
-    } else {
-        ctx->row_limit = ctx->record_count;
-    }
     
     if ((retval = sav_parse_timestamp(ctx, &header)) != READSTAT_OK)
         goto cleanup;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -678,8 +678,8 @@ static readstat_error_t sav_read_dictionary_termination_record(sav_ctx_t *ctx) {
 }
 
 static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len, sav_ctx_t *ctx) {
-    if (ctx->rows_skip) {
-        ctx->rows_skip--;
+    if (ctx->row_offset) {
+        ctx->row_offset--;
         return READSTAT_OK;
     }
 
@@ -808,12 +808,12 @@ static readstat_error_t sav_read_uncompressed_data(sav_ctx_t *ctx,
 
     buffer = readstat_malloc(buffer_len);
 
-    if (ctx->rows_skip) {
-        if (io->seek(buffer_len * ctx->rows_skip, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
+    if (ctx->row_offset) {
+        if (io->seek(buffer_len * ctx->row_offset, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
             retval = READSTAT_ERROR_SEEK;
             goto done;
         }
-        ctx->rows_skip = 0;
+        ctx->row_offset = 0;
     }
 
     while (ctx->row_limit == -1 || ctx->current_row < ctx->row_limit) {
@@ -1582,9 +1582,9 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
     ctx->output_encoding = parser->output_encoding;
     ctx->user_ctx = user_ctx;
     ctx->file_size = file_size;
-    if (parser->rows_skip > 0)
-        ctx->rows_skip = parser->rows_skip;
-    int record_count_after_skipping = ctx->record_count - ctx->rows_skip;
+    if (parser->row_offset > 0)
+        ctx->row_offset = parser->row_offset;
+    int record_count_after_skipping = ctx->record_count - ctx->row_offset;
     if (record_count_after_skipping < 0)
         record_count_after_skipping = 0;
     ctx->row_limit = record_count_after_skipping;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -889,7 +889,9 @@ static readstat_error_t sav_read_compressed_data(sav_ctx_t *ctx,
                 uncompressed_offset = 0;
             }
 
-            if (state.status == SAV_ROW_STREAM_FINISHED_ALL || ctx->current_row == ctx->row_limit)
+            if (state.status == SAV_ROW_STREAM_FINISHED_ALL)
+                goto done;
+            if (ctx->row_limit > 0 && ctx->current_row == ctx->row_limit)
                 goto done;
         }
     }

--- a/src/spss/readstat_zsav_read.c
+++ b/src/spss/readstat_zsav_read.c
@@ -169,7 +169,9 @@ readstat_error_t zsav_read_compressed_data(sav_ctx_t *ctx,
                 uncompressed_offset = 0;
             }
 
-            if (state.status == SAV_ROW_STREAM_FINISHED_ALL || ctx->current_row == ctx->row_limit)
+            if (state.status == SAV_ROW_STREAM_FINISHED_ALL)
+                goto cleanup;
+            if (ctx->row_limit > 0 && ctx->current_row == ctx->row_limit)
                 goto cleanup;
         }
     }

--- a/src/stata/readstat_dta.h
+++ b/src/stata/readstat_dta.h
@@ -87,7 +87,7 @@ typedef struct dta_ctx_s {
     int64_t        nobs;
     size_t         record_len;
     int64_t        row_limit;
-    int64_t        rows_skip;
+    int64_t        row_offset;
     int64_t        current_row;
 
     unsigned int   bswap:1;

--- a/src/stata/readstat_dta.h
+++ b/src/stata/readstat_dta.h
@@ -87,6 +87,7 @@ typedef struct dta_ctx_s {
     int64_t        nobs;
     size_t         record_len;
     int64_t        row_limit;
+    int64_t        rows_skip;
     int64_t        current_row;
 
     unsigned int   bswap:1;

--- a/src/stata/readstat_dta_read.c
+++ b/src/stata/readstat_dta_read.c
@@ -663,7 +663,6 @@ static readstat_error_t dta_handle_rows(dta_ctx_t *ctx) {
             retval = READSTAT_ERROR_SEEK;
             goto cleanup;
         }
-        ctx->row_offset = 0;
     }
 
     for (i=0; i<ctx->row_limit; i++) {
@@ -680,8 +679,8 @@ static readstat_error_t dta_handle_rows(dta_ctx_t *ctx) {
         }
     }
 
-    if (ctx->row_limit < ctx->nobs) {
-        if (io->seek(ctx->record_len * (ctx->nobs - ctx->row_limit), READSTAT_SEEK_CUR, io->io_ctx) == -1)
+    if (ctx->row_limit < ctx->nobs - ctx->row_offset) {
+        if (io->seek(ctx->record_len * (ctx->nobs - ctx->row_offset - ctx->row_limit), READSTAT_SEEK_CUR, io->io_ctx) == -1)
             retval = READSTAT_ERROR_SEEK;
     }
 

--- a/src/stata/readstat_dta_read.c
+++ b/src/stata/readstat_dta_read.c
@@ -658,6 +658,14 @@ static readstat_error_t dta_handle_rows(dta_ctx_t *ctx) {
         goto cleanup;
     }
 
+    if (ctx->rows_skip) {
+        if (io->seek(ctx->record_len * ctx->rows_skip, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
+            retval = READSTAT_ERROR_SEEK;
+            goto cleanup;
+        }
+        ctx->rows_skip = 0;
+    }
+
     for (i=0; i<ctx->row_limit; i++) {
         if (io->read(buf, ctx->record_len, io->io_ctx) != ctx->record_len) {
             retval = READSTAT_ERROR_READ;
@@ -1178,8 +1186,13 @@ readstat_error_t readstat_parse_dta(readstat_parser_t *parser, const char *path,
     ctx->user_ctx = user_ctx;
     ctx->file_size = file_size;
     ctx->handle = parser->handlers;
-    ctx->row_limit = ctx->nobs;
-    if (parser->row_limit > 0 && parser->row_limit < ctx->nobs)
+    if (parser->rows_skip > 0)
+        ctx->rows_skip = parser->rows_skip;
+    int64_t nobs_after_skipping = ctx->nobs - ctx->rows_skip;
+    if (nobs_after_skipping < 0)
+        nobs_after_skipping = 0;
+    ctx->row_limit = nobs_after_skipping;
+    if (parser->row_limit > 0 && parser->row_limit < nobs_after_skipping)
         ctx->row_limit = parser->row_limit;
 
     retval = dta_update_progress(ctx);

--- a/src/stata/readstat_dta_read.c
+++ b/src/stata/readstat_dta_read.c
@@ -1189,8 +1189,10 @@ readstat_error_t readstat_parse_dta(readstat_parser_t *parser, const char *path,
     if (parser->row_offset > 0)
         ctx->row_offset = parser->row_offset;
     int64_t nobs_after_skipping = ctx->nobs - ctx->row_offset;
-    if (nobs_after_skipping < 0)
+    if (nobs_after_skipping < 0) {
         nobs_after_skipping = 0;
+        ctx->row_offset = ctx->nobs;
+    }
     ctx->row_limit = nobs_after_skipping;
     if (parser->row_limit > 0 && parser->row_limit < nobs_after_skipping)
         ctx->row_limit = parser->row_limit;

--- a/src/stata/readstat_dta_read.c
+++ b/src/stata/readstat_dta_read.c
@@ -658,12 +658,12 @@ static readstat_error_t dta_handle_rows(dta_ctx_t *ctx) {
         goto cleanup;
     }
 
-    if (ctx->rows_skip) {
-        if (io->seek(ctx->record_len * ctx->rows_skip, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
+    if (ctx->row_offset) {
+        if (io->seek(ctx->record_len * ctx->row_offset, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
             retval = READSTAT_ERROR_SEEK;
             goto cleanup;
         }
-        ctx->rows_skip = 0;
+        ctx->row_offset = 0;
     }
 
     for (i=0; i<ctx->row_limit; i++) {
@@ -1186,9 +1186,9 @@ readstat_error_t readstat_parse_dta(readstat_parser_t *parser, const char *path,
     ctx->user_ctx = user_ctx;
     ctx->file_size = file_size;
     ctx->handle = parser->handlers;
-    if (parser->rows_skip > 0)
-        ctx->rows_skip = parser->rows_skip;
-    int64_t nobs_after_skipping = ctx->nobs - ctx->rows_skip;
+    if (parser->row_offset > 0)
+        ctx->row_offset = parser->row_offset;
+    int64_t nobs_after_skipping = ctx->nobs - ctx->row_offset;
     if (nobs_after_skipping < 0)
         nobs_after_skipping = 0;
     ctx->row_limit = nobs_after_skipping;

--- a/src/test/test_list.h
+++ b/src/test/test_list.h
@@ -1,17 +1,6 @@
 
 #define RT_FORMAT_TEST_TIMESTAMPS  (RT_FORMAT_DTA_105_AND_NEWER | RT_FORMAT_SPSS | RT_FORMAT_SAS7BDAT)
 
-static rt_test_args_t _test_args[] = {
-    {
-        .row_limit = 0,
-        .row_offset = 0,
-    },
-    {
-        .row_limit = 1,
-        .row_offset = 1,
-    }
-};
-
 static rt_test_group_t _test_groups[] = {
     {
         .label = "Table name",

--- a/src/test/test_list.h
+++ b/src/test/test_list.h
@@ -1,6 +1,17 @@
 
 #define RT_FORMAT_TEST_TIMESTAMPS  (RT_FORMAT_DTA_105_AND_NEWER | RT_FORMAT_SPSS | RT_FORMAT_SAS7BDAT)
 
+static rt_test_args_t _test_args[] = {
+    {
+        .row_limit = 0,
+        .row_offset = 0,
+    },
+    {
+        .row_limit = 1,
+        .row_offset = 1,
+    }
+};
+
 static rt_test_group_t _test_groups[] = {
     {
         .label = "Table name",

--- a/src/test/test_read.c
+++ b/src/test/test_read.c
@@ -101,6 +101,17 @@ void parse_ctx_free(rt_parse_ctx_t *parse_ctx) {
     free(parse_ctx);
 }
 
+long expected_row_count(rt_parse_ctx_t *parse_ctx) {
+    long expected_rows = parse_ctx->file->rows;
+    if (parse_ctx->args->row_offset > 0)
+        expected_rows -= parse_ctx->args->row_offset;
+    if (expected_rows < 0)
+        expected_rows = 0;
+    if (parse_ctx->args->row_limit > 0 && parse_ctx->args->row_limit < expected_rows)
+        expected_rows = parse_ctx->args->row_limit;
+    return expected_rows;
+}
+
 static int handle_metadata(readstat_metadata_t *metadata, void *ctx) {
     rt_parse_ctx_t *rt_ctx = (rt_parse_ctx_t *)ctx;
 
@@ -324,16 +335,5 @@ cleanup:
     readstat_parser_free(parser);
 
     return error;
-}
-
-long expected_row_count(rt_parse_ctx_t *parse_ctx) {
-    long expected_rows = parse_ctx->file->rows;
-    if (parse_ctx->args->row_offset > 0)
-        expected_rows -= parse_ctx->args->row_offset;
-    if (expected_rows < 0)
-        expected_rows = 0;
-    if (parse_ctx->args->row_limit > 0 && parse_ctx->args->row_limit < expected_rows)
-        expected_rows = parse_ctx->args->row_limit;
-    return expected_rows;
 }
 

--- a/src/test/test_read.c
+++ b/src/test/test_read.c
@@ -309,7 +309,7 @@ readstat_error_t read_file(rt_parse_ctx_t *parse_ctx, long format) {
             parse_ctx->variables_count, "Column count");
 
     long expected_rows = parse_ctx->file->rows;
-    if (parse_ctx->args->row_offset > 0);
+    if (parse_ctx->args->row_offset > 0)
         expected_rows -= parse_ctx->args->row_offset;
     if (expected_rows < 0)
         expected_rows = 0;

--- a/src/test/test_read.c
+++ b/src/test/test_read.c
@@ -120,7 +120,7 @@ static int handle_metadata(readstat_metadata_t *metadata, void *ctx) {
 
     if (obs_count != -1) {
         push_error_if_doubles_differ(rt_ctx, 
-                rt_ctx->file->rows, obs_count, 
+                expected_row_count(rt_ctx), obs_count, 
                 "Number of observations");
     }
 
@@ -308,14 +308,7 @@ readstat_error_t read_file(rt_parse_ctx_t *parse_ctx, long format) {
     push_error_if_doubles_differ(parse_ctx, parse_ctx->file->columns_count,
             parse_ctx->variables_count, "Column count");
 
-    long expected_rows = parse_ctx->file->rows;
-    if (parse_ctx->args->row_offset > 0)
-        expected_rows -= parse_ctx->args->row_offset;
-    if (expected_rows < 0)
-        expected_rows = 0;
-    if (parse_ctx->args->row_limit > 0 && parse_ctx->args->row_limit < expected_rows)
-        expected_rows = parse_ctx->args->row_limit;
-    push_error_if_doubles_differ(parse_ctx, expected_rows,
+    push_error_if_doubles_differ(parse_ctx, expected_row_count(parse_ctx),
             parse_ctx->obs_index + 1, "Row count");
 
     long value_labels_count = 0;
@@ -331,5 +324,16 @@ cleanup:
     readstat_parser_free(parser);
 
     return error;
+}
+
+long expected_row_count(rt_parse_ctx_t *parse_ctx) {
+    long expected_rows = parse_ctx->file->rows;
+    if (parse_ctx->args->row_offset > 0)
+        expected_rows -= parse_ctx->args->row_offset;
+    if (expected_rows < 0)
+        expected_rows = 0;
+    if (parse_ctx->args->row_limit > 0 && parse_ctx->args->row_limit < expected_rows)
+        expected_rows = parse_ctx->args->row_limit;
+    return expected_rows;
 }
 

--- a/src/test/test_read.h
+++ b/src/test/test_read.h
@@ -1,5 +1,5 @@
 
-rt_parse_ctx_t *parse_ctx_init(rt_buffer_t *buffer, rt_test_file_t *file);
+rt_parse_ctx_t *parse_ctx_init(rt_buffer_t *buffer, rt_test_file_t *file, rt_test_args_t *args);
 void parse_ctx_reset(rt_parse_ctx_t *parse_ctx, long file_format);
 void parse_ctx_free(rt_parse_ctx_t *parse_ctx);
 

--- a/src/test/test_readstat.c
+++ b/src/test/test_readstat.c
@@ -19,6 +19,17 @@
 #include "test_write.h"
 #include "test_list.h"
 
+static rt_test_args_t _test_args[] = {
+    {
+        .row_limit = 0,
+        .row_offset = 0,
+    },
+    {
+        .row_limit = 1,
+        .row_offset = 1,
+    }
+};
+
 static void dump_buffer(rt_buffer_t *buffer, long format) {
     char filename[128];
     snprintf(filename, sizeof(filename), "/tmp/test_readstat.%s", 

--- a/src/test/test_readstat.c
+++ b/src/test/test_readstat.c
@@ -37,53 +37,56 @@ int main(int argc, char *argv[]) {
     rt_buffer_t *buffer = buffer_init();
     readstat_error_t error = READSTAT_OK;
 
-    int g, t, f;
+    int g, t, a, f;
 
     for (g=0; g<sizeof(_test_groups)/sizeof(_test_groups[0]); g++) {
         for (t=0; t<MAX_TESTS_PER_GROUP && _test_groups[g].tests[t].label[0]; t++) {
             rt_test_file_t *file = &_test_groups[g].tests[t];
-            rt_parse_ctx_t *parse_ctx = parse_ctx_init(buffer, file);
+            for (a=0; a<sizeof(_test_args)/sizeof(_test_args[0]); a++) {
+                rt_test_args_t *args = &_test_args[a];
+                rt_parse_ctx_t *parse_ctx = parse_ctx_init(buffer, file, args);
 
-            for (f=RT_FORMAT_DTA_104; f<RT_FORMAT_ALL; f*=2) {
-                if (!(file->test_formats & f))
-                    continue;
+                for (f=RT_FORMAT_DTA_104; f<RT_FORMAT_ALL; f*=2) {
+                    if (!(file->test_formats & f))
+                        continue;
 
-                int old_errors_count = parse_ctx->errors_count;
-                parse_ctx_reset(parse_ctx, f);
+                    int old_errors_count = parse_ctx->errors_count;
+                    parse_ctx_reset(parse_ctx, f);
 
-                error = write_file_to_buffer(file, buffer, f);
-                if (error != file->write_error) {
-                    push_error_if_codes_differ(parse_ctx, file->write_error, error);
-                    error = READSTAT_OK;
-                    continue;
+                    error = write_file_to_buffer(file, buffer, f);
+                    if (error != file->write_error) {
+                        push_error_if_codes_differ(parse_ctx, file->write_error, error);
+                        error = READSTAT_OK;
+                        continue;
+                    }
+                    if (error != READSTAT_OK) {
+                        error = READSTAT_OK;
+                        continue;
+                    }
+
+                    error = read_file(parse_ctx, f);
+                    if (error != READSTAT_OK)
+                        break;
+
+                    if (old_errors_count != parse_ctx->errors_count)
+                        dump_buffer(buffer, f);
                 }
-                if (error != READSTAT_OK) {
-                    error = READSTAT_OK;
-                    continue;
+
+                if (parse_ctx->errors_count) {
+                    int i;
+                    for (i=0; i<parse_ctx->errors_count; i++) {
+                        print_error(&parse_ctx->errors[i]);
+                    }
+                    parse_ctx_free(parse_ctx);
+                    buffer_free(buffer);
+                    return 1;
                 }
 
-                error = read_file(parse_ctx, f);
-                if (error != READSTAT_OK)
-                    break;
-
-                if (old_errors_count != parse_ctx->errors_count)
-                    dump_buffer(buffer, f);
-            }
-
-            if (parse_ctx->errors_count) {
-                int i;
-                for (i=0; i<parse_ctx->errors_count; i++) {
-                    print_error(&parse_ctx->errors[i]);
-                }
                 parse_ctx_free(parse_ctx);
-                buffer_free(buffer);
-                return 1;
+
+                if (error != READSTAT_OK)
+                    goto cleanup;
             }
-
-            parse_ctx_free(parse_ctx);
-
-            if (error != READSTAT_OK)
-                goto cleanup;
         }
     }
 

--- a/src/test/test_types.h
+++ b/src/test/test_types.h
@@ -70,6 +70,11 @@ typedef struct rt_test_group_s {
     rt_test_file_t   tests[MAX_TESTS_PER_GROUP];
 } rt_test_group_t;
 
+typedef struct rt_test_args_s {
+    long             row_limit;
+    long             row_offset;    
+} rt_test_args_t;
+
 
 typedef struct rt_error_s {
     readstat_value_t received;
@@ -98,6 +103,8 @@ typedef struct rt_parse_ctx_s {
     long             variables_count;
     long             value_labels_count;
     long             notes_count;
+
+    rt_test_args_t  *args;
 
     rt_test_file_t  *file;
     long             file_format;


### PR DESCRIPTION
Closes #141.

Implemented skipping rows at the start of the file by seeking past when possible, and doing minimal handling when not. I'm assuming this won't be very efficient for compressed data, because seeking isn't really an option (I think?), but should work well for uncompressed formats.