### PR TITLE
make xpt v8 SAS-readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test_double_decimals
 *.py
 *.tar.gz
 *.zip
+.DS_Store

--- a/src/sas/readstat_xport_read.c
+++ b/src/sas/readstat_xport_read.c
@@ -449,8 +449,13 @@ static readstat_error_t xport_read_variables(xport_ctx_t *ctx) {
         variable->decimals = namestr.nfd;
         variable->alignment = namestr.nfj ? READSTAT_ALIGNMENT_RIGHT : READSTAT_ALIGNMENT_LEFT;
 
-        readstat_convert(variable->name, sizeof(variable->name),
-                namestr.nname, sizeof(namestr.nname), ctx->converter);
+        if (ctx->version == 5) {
+            readstat_convert(variable->name, sizeof(variable->name),
+                    namestr.nname, sizeof(namestr.nname), ctx->converter);
+        } else {
+            readstat_convert(variable->name, sizeof(variable->name),
+                    namestr.longname, sizeof(namestr.longname), ctx->converter);
+        }
         if (retval != READSTAT_OK)
             goto cleanup;
 

--- a/src/sas/readstat_xport_write.c
+++ b/src/sas/readstat_xport_write.c
@@ -87,9 +87,11 @@ static readstat_error_t xport_write_variables(readstat_writer_t *writer) {
         readstat_variable_t *variable = readstat_get_variable(writer, i);
         size_t width = xport_variable_width(variable->type, variable->user_width);
         xport_namestr_t namestr = { 
-            .nvar0 = i,
+            .nvar0 = i+1,
             .nlng = width,
-            .npos = offset
+            .npos = offset,
+            .niform = "        ",
+            .nform = "        "
         };
         if (readstat_variable_get_type_class(variable) == READSTAT_TYPE_CLASS_STRING) {
             namestr.ntype = SAS_COLUMN_TYPE_CHR;


### PR DESCRIPTION
Hi Evan!

I propose very few changes to make xpt version 8 files SAS-readable. On some examples ReadStat now produces readable files by setting format and informat name to blank (not nulls).

Given https://documentation.sas.com/?docsetId=movefile&docsetTarget=p0ld1i106e1xm7n16eefi7qgj8m9.htm&docsetVersion=9.4&locale=en I would be willing to improve on this PR with target to preserve also long variable names, formats, and informats. Would that be of interest to you?