### PR TITLE
implements duration support in extract_metadata

### DIFF
--- a/src/bin/extract_metadata.c
+++ b/src/bin/extract_metadata.c
@@ -14,12 +14,6 @@
 #include "write/json/write_missing_values.h"
 #include "write/json/write_value_labels.h"
 
-typedef enum extract_metadata_type_e {
-    EXTRACT_METADATA_TYPE_NUMERIC,
-    EXTRACT_METADATA_TYPE_STRING,
-    EXTRACT_METADATA_TYPE_UNKNOWN
-} extract_metadata_type_t;
-
 static const char* extract_metadata_type_str(extract_metadata_type_t t) {
     switch (t) {
      case EXTRACT_METADATA_TYPE_NUMERIC:
@@ -31,16 +25,6 @@ static const char* extract_metadata_type_str(extract_metadata_type_t t) {
     }
     return "UNKNOWN";
 }
-
-typedef enum extract_metadata_format_e {
-    EXTRACT_METADATA_FORMAT_NUMBER,
-    EXTRACT_METADATA_FORMAT_PERCENT,
-    EXTRACT_METADATA_FORMAT_CURRENCY,
-    EXTRACT_METADATA_FORMAT_DATE,
-    EXTRACT_METADATA_FORMAT_TIME,
-    EXTRACT_METADATA_FORMAT_DATE_TIME,
-    EXTRACT_METADATA_FORMAT_UNSPECIFIED
-} extract_metadata_format_t;
 
 static const char* extract_metadata_format_str(extract_metadata_format_t format) {
     switch (format) {

--- a/src/bin/extract_metadata.c
+++ b/src/bin/extract_metadata.c
@@ -121,115 +121,145 @@ static int handle_variable_sav(int index, readstat_variable_t *variable, const c
 
         // Extract format
         // SPSS data types: https://libguides.library.kent.edu/SPSS/DatesTime
-        // Pattern formats: https://developers.google.com/sheets/api/guides/formats
+        // Pattern formats: https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
         // TODO: Extract currency
         if (vformat) {
             if (hasPrefix(vformat, "DATE9") == 0) {
+                // e.g. 31-JAN-13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "d-m-y";
+                pattern = "dd-MMM-yy";
             } else if (hasPrefix(vformat, "DATE11") == 0) {
+                // e.g. 31-JAN-13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "dd-m-yyyy+";
+                pattern = "dd-MMM-yyyy";
             } else if (hasPrefix(vformat, "ADATE8") == 0) {
+                // e.g. 01/31/13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "m/d/y";
+                pattern = "MM/dd/yy";
             } else if (hasPrefix(vformat, "ADATE10") == 0) {
+                // e.g. 01/31/2013
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "m/d/yyyy+";
+                pattern = "MM/dd/yyyy";
             } else if (hasPrefix(vformat, "EDATE8") == 0) {
+                // e.g. 31.01.13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "d.m.y";
+                pattern = "dd.MM.yy";
             } else if (hasPrefix(vformat, "EDATE10") == 0) {
+                // e.g. 31.01.2013
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "d.m.yyyy+";
+                pattern = "dd.MM.yyyy";
             } else if (hasPrefix(vformat, "SDATE8") == 0) {
+                // e.g. 13/01/31
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "y/m/d";
+                pattern = "yy/MM/dd";
             } else if (hasPrefix(vformat, "SDATE10") == 0) {
+                // e.g. 2013/01/31
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "yyyy+/m/d";
+                pattern = "yyyy/MM/dd";
             } else if (hasPrefix(vformat, "DATETIME17") == 0) {
+                // e.g. 31-JAN-2013 01:02
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "d-mm-yyyy+ h:mm";
+                pattern = "dd-MMM-yyyy hh:mm";
             } else if (hasPrefix(vformat, "DATETIME20") == 0) {
+                // e.g. 31-JAN-2013 01:02:33
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "d-mm-yyyy+ h:mm:ss";
+                pattern = "dd-MMM-yyyy hh:mm:ss";
             } else if (hasPrefix(vformat, "DATETIME23.2") == 0) {
+                // e.g. 31-JAN-2013 01:02:33.72
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "d-mm-yyy+ h:mm:ss";
+                pattern = "dd-MMM-yyyy hh:mm:ss.SS+";
             } else if (hasPrefix(vformat, "YMDHMS16") == 0) {
+                // e.g. 2013-01-31 1:02
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy+-m-d h:mm";
+                pattern = "yyyy-MM-dd h:mm";
             } else if (hasPrefix(vformat, "YMDHMS19") == 0) {
+                // e.g. 2013-01-31 1:02:33
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy+-m-d h:mm:ss";
+                pattern = "yyyy-MM-dd h:mm:ss";
             } else if (hasPrefix(vformat, "YMDHMS19.2") == 0) {
+                // e.g. 2013-01-31 1:02:33.72
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy+-m-d h:mm:ss";
+                pattern = "yyyy-MM-dd h:mm:ss.SS+";
             } else if (hasPrefix(vformat, "MTIME5") == 0) {
+                // e.g. 1754:36
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[m+]:[s+]";
             } else if (hasPrefix(vformat, "MTIME8.2") == 0) {
+                // e.g. 1754:36.58
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[m+]:[s+]";
             } else if (hasPrefix(vformat, "TIME5") == 0) {
+                // e.g. 29:14
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[h+]:[m+]";
             } else if (hasPrefix(vformat, "TIME8") == 0) {
+                // e.g. 29:14:36
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[h+]:[m+]:[s+]";
             } else if (hasPrefix(vformat, "TIME11.2") == 0) {
+                // e.g. 29:14:36.58
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[h+]:[m+]:[s+]";
             } else if (hasPrefix(vformat, "DTIME9") == 0) {
+                // e.g. 1 05:14
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[d+] [h+]:[m+]";
             } else if (hasPrefix(vformat, "DTIME12") == 0) {
+                // e.g. 1 05:14:36
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[d+] [h+]:[m+]:[s+]";
             } else if (hasPrefix(vformat, "DTIME15.2") == 0) {
+                // e.g. 1 05:14:36.58
                 format = EXTRACT_METADATA_FORMAT_TIME;
                 pattern = "[d+] [h+]:[m+]:[s+]";
             } else if (hasPrefix(vformat, "JDATE5") == 0) {
+                // e.g. 13031
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "yd";
+                pattern = "yyddd";
             } else if (hasPrefix(vformat, "JDATE7") == 0) {
+                // e.g. 2013031
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "yyyy+d";
+                pattern = "yyyyddd";
             } else if (hasPrefix(vformat, "QYR6") == 0) {
+                // e.g. 1 Q 13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "q Q y";
+                pattern = "Q 'Q' y";
             } else if (hasPrefix(vformat, "QYR8") == 0) {
+                // e.g. 1 Q 2013
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "q Q yyyy+";
+                pattern = "Q 'Q' yyyy";
             } else if (hasPrefix(vformat, "MOYR6") == 0) {
+                // e.g. JAN 13
                 format = EXTRACT_METADATA_FORMAT_DATE;
                 pattern = "mmm yy";
             } else if (hasPrefix(vformat, "MOYR8") == 0) {
+                // e.g. JAN 2013
                 format = EXTRACT_METADATA_FORMAT_DATE;
                 pattern = "mmm yyyy";
             } else if (hasPrefix(vformat, "WKYR8") == 0) {
+                // e.g. 5 WK 13
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "w WK y";
+                pattern = "w 'WK' yy";
             } else if (hasPrefix(vformat, "WKYR10") == 0) {
+                // e.g. 5 WK 2013
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "w WK yyyy+";
+                pattern = "w 'WK' yyyy";
             } else if (hasPrefix(vformat, "WKDAY3") == 0) {
-                // Day of the week, three letter abbreviation (e.g., "Mon").
+                // Day of the week, three letter abbreviation (e.g. "Mon").
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "ddd";
+                pattern = "eee";
             } else if (hasPrefix(vformat, "WKDAY9") == 0) {
-                // Day of the week, full name.
+                // Day of the week, full name. (e.g. "Monday")
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "dddd+";
+                pattern = "eeee";
             } else if (hasPrefix(vformat, "MONTH3") == 0) {
-                // Three letter month abbreviation (e.g., "Feb").
+                // Three letter month abbreviation (e.g. "Feb").
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "mmm";
+                pattern = "MMM";
             } else if (hasPrefix(vformat, "MONTH9") == 0) {
-                // Full month name. mmmmmm+ also matches this.
+                // Full month name. (e.g. "February")
                 format = EXTRACT_METADATA_FORMAT_DATE;
-                pattern = "mmmm";
+                pattern = "MMMM";
             } else {
                 format = EXTRACT_METADATA_FORMAT_NUMBER;
                 decimals = extract_decimals(vformat, 'F');
@@ -294,7 +324,7 @@ static int handle_variable_dta(int index, readstat_variable_t *variable, const c
         type = EXTRACT_METADATA_TYPE_NUMERIC;
 
         // Extract format
-        // Pattern formats: https://developers.google.com/sheets/api/guides/formats
+        // Pattern formats: https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
         if (vformat) {
             if (strcmp(vformat, "%d") == 0) {
                 format = EXTRACT_METADATA_FORMAT_DATE;

--- a/src/bin/extract_metadata.h
+++ b/src/bin/extract_metadata.h
@@ -11,4 +11,20 @@ typedef struct context {
     readstat_label_set_t *label_set;
 } context;
 
+typedef enum extract_metadata_type_e {
+    EXTRACT_METADATA_TYPE_NUMERIC,
+    EXTRACT_METADATA_TYPE_STRING,
+    EXTRACT_METADATA_TYPE_UNKNOWN
+} extract_metadata_type_t;
+
+typedef enum extract_metadata_format_e {
+    EXTRACT_METADATA_FORMAT_NUMBER,
+    EXTRACT_METADATA_FORMAT_PERCENT,
+    EXTRACT_METADATA_FORMAT_CURRENCY,
+    EXTRACT_METADATA_FORMAT_DATE,
+    EXTRACT_METADATA_FORMAT_TIME,
+    EXTRACT_METADATA_FORMAT_DATE_TIME,
+    EXTRACT_METADATA_FORMAT_UNSPECIFIED
+} extract_metadata_format_t;
+
 #endif

--- a/src/bin/read_csv/json_metadata.c
+++ b/src/bin/read_csv/json_metadata.c
@@ -104,7 +104,7 @@ char* copy_variable_property(struct json_metadata* md, const char* varname, cons
 	if (tok == NULL) {
 		return NULL;
 	}
-	
+
 	int len = tok->end - tok->start;
 	if (len == 0) {
 		return NULL;
@@ -186,7 +186,7 @@ int get_decimals(struct json_metadata* md, const char* varname) {
 	}
 }
 
-metadata_column_type_t column_type(struct json_metadata* md, const char* varname, int output_format) {
+extract_metadata_type_t column_type(struct json_metadata* md, const char* varname, int output_format) {
 	jsmntok_t* typ = find_variable_property(md->js, md->tok, varname, "type");
 	if (!typ) {
 		fprintf(stderr, "Could not find type of variable %s in metadata\n", varname);
@@ -194,15 +194,35 @@ metadata_column_type_t column_type(struct json_metadata* md, const char* varname
 	}
 
 	if (match_token(md->js, typ, "NUMERIC")) {
-		return METADATA_COLUMN_TYPE_NUMERIC;
+		return EXTRACT_METADATA_TYPE_NUMERIC;
 	} else if (match_token(md->js, typ, "STRING")) {
-		return METADATA_COLUMN_TYPE_STRING;
-	} else if (match_token(md->js, typ, "DATE")) {
-		return METADATA_COLUMN_TYPE_DATE;
+		return EXTRACT_METADATA_TYPE_STRING;
 	} else {
 		fprintf(stderr, "%s: %d: Unknown metadata type for variable %s\n", __FILE__, __LINE__, varname);
 		exit(EXIT_FAILURE);
 	}
+}
+
+extract_metadata_format_t column_format(struct json_metadata* md, const char* varname) {
+	jsmntok_t* typ = find_variable_property(md->js, md->tok, varname, "format");
+	if (!typ) {
+		return EXTRACT_METADATA_FORMAT_UNSPECIFIED;
+	}
+
+	if (match_token(md->js, typ, "NUMBER")) {
+		return EXTRACT_METADATA_FORMAT_NUMBER;
+	} else if (match_token(md->js, typ, "PERCENT")) {
+		return EXTRACT_METADATA_FORMAT_PERCENT;
+	} else if (match_token(md->js, typ, "CURRENCY")) {
+		return EXTRACT_METADATA_FORMAT_CURRENCY;
+	} else if (match_token(md->js, typ, "DATE")) {
+		return EXTRACT_METADATA_FORMAT_DATE;
+	} else if (match_token(md->js, typ, "TIME")) {
+		return EXTRACT_METADATA_FORMAT_TIME;
+	} else if (match_token(md->js, typ, "DATE_TIME")) {
+		return EXTRACT_METADATA_FORMAT_DATE_TIME;
+	}
+	return EXTRACT_METADATA_FORMAT_UNSPECIFIED;
 }
 
 double get_double_from_token(const char *js, jsmntok_t* token) {
@@ -244,7 +264,7 @@ struct json_metadata* get_json_metadata(const char* filename) {
 		fprintf(stderr, "malloc(): error:%s\n", strerror(errno));
 		goto errexit;
 	}
-	
+
 	fd = fopen(filename, "rb");
 	if (fd == NULL) {
 		fprintf(stderr, "Could not open %s: %s\n", filename, strerror(errno));

--- a/src/bin/read_csv/json_metadata.h
+++ b/src/bin/read_csv/json_metadata.h
@@ -1,5 +1,6 @@
 #include "jsmn.h"
 #include "../../readstat.h"
+#include "../extract_metadata.h"
 
 #ifndef __JSON_METADATA_H_
 #define __JSON_METADATA_H_
@@ -9,14 +10,9 @@ typedef struct json_metadata {
     jsmntok_t* tok;
 } json_metadata;
 
-typedef enum metadata_column_type_e {
-    METADATA_COLUMN_TYPE_STRING,
-    METADATA_COLUMN_TYPE_NUMERIC,
-    METADATA_COLUMN_TYPE_DATE,
-} metadata_column_type_t;
-
 struct json_metadata* get_json_metadata(const char* filename);
-metadata_column_type_t column_type(struct json_metadata* md, const char* varname, int output_format);
+extract_metadata_type_t column_type(struct json_metadata* md, const char* varname, int output_format);
+extract_metadata_format_t column_format(struct json_metadata* md, const char* varname);
 void free_json_metadata(struct json_metadata*);
 
 int get_decimals(struct json_metadata* md, const char* varname);

--- a/src/bin/read_csv/mod_csv.c
+++ b/src/bin/read_csv/mod_csv.c
@@ -27,10 +27,10 @@ static void produce_column_header_csv(void *csv_metadata, const char *column, re
             var->type = READSTAT_TYPE_DOUBLE;
         break;
         case EXTRACT_METADATA_FORMAT_PERCENT:
-            var->type = READSTAT_TYPE_STRING;
+            var->type = READSTAT_TYPE_DOUBLE;
         break;
         case EXTRACT_METADATA_FORMAT_CURRENCY:
-            var->type = READSTAT_TYPE_STRING;
+            var->type = READSTAT_TYPE_DOUBLE;
         break;
         case EXTRACT_METADATA_FORMAT_DATE:
             var->type = READSTAT_TYPE_STRING;

--- a/src/bin/read_csv/mod_csv.c
+++ b/src/bin/read_csv/mod_csv.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "../../readstat.h"
+#include "../extract_metadata.h"
 #include "json_metadata.h"
 #include "read_module.h"
 #include "csv_metadata.h"
@@ -17,13 +18,39 @@ rs_read_module_t rs_read_mod_csv = {
 
 static void produce_column_header_csv(void *csv_metadata, const char *column, readstat_variable_t* var) {
     struct csv_metadata *c = (struct csv_metadata *)csv_metadata;
-    metadata_column_type_t coltype = column_type(c->json_md, column, c->output_format);
-    if (coltype == METADATA_COLUMN_TYPE_DATE) {
+    extract_metadata_type_t coltype = column_type(c->json_md, column, c->output_format);
+    switch (coltype) {
+    case EXTRACT_METADATA_TYPE_NUMERIC:;
+        extract_metadata_format_t colformat = column_format(c->json_md, column);
+        switch (colformat) {
+        case EXTRACT_METADATA_FORMAT_NUMBER:
+            var->type = READSTAT_TYPE_DOUBLE;
+        break;
+        case EXTRACT_METADATA_FORMAT_PERCENT:
+            var->type = READSTAT_TYPE_STRING;
+        break;
+        case EXTRACT_METADATA_FORMAT_CURRENCY:
+            var->type = READSTAT_TYPE_STRING;
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE:
+            var->type = READSTAT_TYPE_STRING;
+        break;
+        case EXTRACT_METADATA_FORMAT_TIME:
+            var->type = READSTAT_TYPE_STRING;
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE_TIME:
+            var->type = READSTAT_TYPE_STRING;
+        break;
+        default:
+            var->type = READSTAT_TYPE_DOUBLE;
+        }
+        break;
+    case EXTRACT_METADATA_TYPE_STRING:
         var->type = READSTAT_TYPE_STRING;
-    } else if (coltype == METADATA_COLUMN_TYPE_NUMERIC) {
-        var->type = READSTAT_TYPE_DOUBLE;
-    } else if (coltype == METADATA_COLUMN_TYPE_STRING) {
-        var->type = READSTAT_TYPE_STRING;
+        break;
+    case EXTRACT_METADATA_TYPE_UNKNOWN:
+        // ...
+        break;
     }
 }
 

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -195,13 +195,7 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
         extract_metadata_format_t colformat = column_format(c->json_md, column);
         switch (colformat) {
         case EXTRACT_METADATA_FORMAT_NUMBER:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
-        break;
         case EXTRACT_METADATA_FORMAT_PERCENT:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
-        break;
         case EXTRACT_METADATA_FORMAT_CURRENCY:
             var->type = READSTAT_TYPE_DOUBLE;
             snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
@@ -211,9 +205,6 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
             snprintf(var->format, sizeof(var->format), "%s", "%td");
         break;
         case EXTRACT_METADATA_FORMAT_TIME:
-            var->type = READSTAT_TYPE_INT32;
-            snprintf(var->format, sizeof(var->format), "%s", "%td");
-        break;
         case EXTRACT_METADATA_FORMAT_DATE_TIME:
             var->type = READSTAT_TYPE_INT32;
             snprintf(var->format, sizeof(var->format), "%s", "%tC");

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -216,7 +216,8 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
         break;
         case EXTRACT_METADATA_FORMAT_DATE_TIME:
             var->type = READSTAT_TYPE_INT32;
-            snprintf(var->format, sizeof(var->format), "%s", "%td");
+            snprintf(var->format, sizeof(var->format), "%s", "%tC");
+            // %tC => is equivalent to coordinated universal time (UTC)
         break;
         default:
             var->type = READSTAT_TYPE_DOUBLE;

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -147,7 +147,7 @@ static void produce_missingness_discrete_dta(struct csv_metadata *c, jsmntok_t* 
     int j = 1;
     for (int i=0; i<values->size; i++) {
         jsmntok_t* missing_value_token = values + j;
-        if (is_date) { 
+        if (is_date) {
             dta_add_missing_date(var, get_dta_days_from_token(js, missing_value_token));
         } else if (var->type == READSTAT_TYPE_DOUBLE) {
             dta_add_missing_double(var, get_double_from_token(js, missing_value_token));
@@ -166,7 +166,7 @@ void produce_missingness_dta(void *csv_metadata, const char* column) {
     const char *js = c->json_md->js;
     readstat_variable_t* var = &c->variables[c->columns];
     var->missingness.missing_ranges_count = 0;
-    
+
     jsmntok_t* missing = find_variable_property(js, c->json_md->tok, column, "missing");
     if (!missing) {
         return;
@@ -190,14 +190,39 @@ void produce_missingness_dta(void *csv_metadata, const char* column) {
 
 void produce_column_header_dta(void *csv_metadata, const char *column, readstat_variable_t* var) {
     struct csv_metadata *c = (struct csv_metadata *)csv_metadata;
-    metadata_column_type_t coltype = column_type(c->json_md, column, c->output_format);
-    if (coltype == METADATA_COLUMN_TYPE_DATE) {
-        snprintf(var->format, sizeof(var->format), "%s", "%td");
-        var->type = READSTAT_TYPE_INT32;
-    } else if (coltype == METADATA_COLUMN_TYPE_NUMERIC) {
-        var->type = READSTAT_TYPE_DOUBLE;
-        snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
-    } else if (coltype == METADATA_COLUMN_TYPE_STRING) {
+    extract_metadata_type_t coltype = column_type(c->json_md, column, c->output_format);
+    if (coltype == EXTRACT_METADATA_TYPE_NUMERIC) {
+        extract_metadata_format_t colformat = column_format(c->json_md, column);
+        switch (colformat) {
+        case EXTRACT_METADATA_FORMAT_NUMBER:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_PERCENT:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_CURRENCY:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE:
+            var->type = READSTAT_TYPE_INT32;
+            snprintf(var->format, sizeof(var->format), "%s", "%td");
+        break;
+        case EXTRACT_METADATA_FORMAT_TIME:
+            var->type = READSTAT_TYPE_INT32;
+            snprintf(var->format, sizeof(var->format), "%s", "%td");
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE_TIME:
+            var->type = READSTAT_TYPE_INT32;
+            snprintf(var->format, sizeof(var->format), "%s", "%td");
+        break;
+        default:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%%9.%df", get_decimals(c->json_md, column));
+        }
+    } else if (coltype == EXTRACT_METADATA_TYPE_STRING) {
         var->type = READSTAT_TYPE_STRING;
     }
 }
@@ -214,7 +239,7 @@ static void produce_value_label_int32_date_dta(const char* column, struct csv_me
         .v = { .i32_value = days },
         .type = READSTAT_TYPE_INT32,
     };
-    
+
     int missing_ranges_count = readstat_variable_get_missing_ranges_count(variable);
     for (int i=0; i<missing_ranges_count; i++) {
         readstat_value_t lo_val = readstat_variable_get_missing_range_lo(variable, i);
@@ -302,7 +327,7 @@ static readstat_value_t value_int32_date_dta(const char *s, size_t len, struct c
         fprintf(stderr, "%s:%d not a date: %s\n", __FILE__, __LINE__, (char*)s);
         exit(EXIT_FAILURE);
     }
-    
+
     int missing_ranges_count = readstat_variable_get_missing_ranges_count(var);
     for (int i=0; i<missing_ranges_count; i++) {
         readstat_value_t lo_val = readstat_variable_get_missing_range_lo(var, i);

--- a/src/bin/read_csv/mod_sav.c
+++ b/src/bin/read_csv/mod_sav.c
@@ -53,7 +53,7 @@ static void produce_missingness_discrete_sav(struct csv_metadata *c, jsmntok_t* 
     int j = 1;
     for (int i=0; i<values->size; i++) {
         jsmntok_t* missing_value_token = values + j;
-        if (is_date) { 
+        if (is_date) {
             readstat_variable_add_missing_double_value(var, get_double_date_missing_sav(js, missing_value_token));
         } else if (var->type == READSTAT_TYPE_DOUBLE) {
             readstat_variable_add_missing_double_value(var, get_double_from_token(js, missing_value_token));
@@ -101,7 +101,7 @@ void produce_missingness_sav(void *csv_metadata, const char* column) {
     const char *js = c->json_md->js;
     readstat_variable_t* var = &c->variables[c->columns];
     var->missingness.missing_ranges_count = 0;
-    
+
     jsmntok_t* missing = find_variable_property(js, c->json_md->tok, column, "missing");
     if (!missing) {
         return;
@@ -125,14 +125,39 @@ void produce_missingness_sav(void *csv_metadata, const char* column) {
 
 void produce_column_header_sav(void *csv_metadata, const char *column, readstat_variable_t* var) {
     struct csv_metadata *c = (struct csv_metadata *)csv_metadata;
-    metadata_column_type_t coltype = column_type(c->json_md, column, c->output_format);
-    if (coltype == METADATA_COLUMN_TYPE_DATE) {
-        var->type = READSTAT_TYPE_DOUBLE;
-        snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
-    } else if (coltype == METADATA_COLUMN_TYPE_NUMERIC) {
-        var->type = READSTAT_TYPE_DOUBLE;
-        snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
-    } else if (coltype == METADATA_COLUMN_TYPE_STRING) {
+    extract_metadata_type_t coltype = column_type(c->json_md, column, c->output_format);
+    if (coltype == EXTRACT_METADATA_TYPE_NUMERIC) {
+        extract_metadata_format_t colformat = column_format(c->json_md, column);
+        switch (colformat) {
+        case EXTRACT_METADATA_FORMAT_NUMBER:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_PERCENT:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_CURRENCY:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
+        break;
+        case EXTRACT_METADATA_FORMAT_TIME:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
+        break;
+        case EXTRACT_METADATA_FORMAT_DATE_TIME:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
+        break;
+        default:
+            var->type = READSTAT_TYPE_DOUBLE;
+            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
+        }
+    } else if (coltype == EXTRACT_METADATA_TYPE_STRING) {
         var->type = READSTAT_TYPE_STRING;
     }
 }

--- a/src/bin/read_csv/mod_sav.c
+++ b/src/bin/read_csv/mod_sav.c
@@ -130,25 +130,13 @@ void produce_column_header_sav(void *csv_metadata, const char *column, readstat_
         extract_metadata_format_t colformat = column_format(c->json_md, column);
         switch (colformat) {
         case EXTRACT_METADATA_FORMAT_NUMBER:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
-        break;
         case EXTRACT_METADATA_FORMAT_PERCENT:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
-        break;
         case EXTRACT_METADATA_FORMAT_CURRENCY:
             var->type = READSTAT_TYPE_DOUBLE;
             snprintf(var->format, sizeof(var->format), "F8.%d", get_decimals(c->json_md, column));
         break;
         case EXTRACT_METADATA_FORMAT_DATE:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
-        break;
         case EXTRACT_METADATA_FORMAT_TIME:
-            var->type = READSTAT_TYPE_DOUBLE;
-            snprintf(var->format, sizeof(var->format), "%s", "EDATE40");
-        break;
         case EXTRACT_METADATA_FORMAT_DATE_TIME:
             var->type = READSTAT_TYPE_DOUBLE;
             snprintf(var->format, sizeof(var->format), "%s", "EDATE40");

--- a/variablemetadata_schema.json
+++ b/variablemetadata_schema.json
@@ -19,7 +19,9 @@
                 },
                 "separator": {
                     "enum": [
-                        ",", ";", "\t"
+                        ",",
+                        ";",
+                        "\t"
                     ]
                 },
                 "variables": {
@@ -32,9 +34,6 @@
                             },
                             {
                                 "$ref": "#/definitions/SPSS-STRING"
-                            },
-                            {
-                                "$ref": "#/definitions/SPSS-DATE"
                             }
                         ]
                     }
@@ -58,6 +57,23 @@
                     "type": "string",
                     "minLength": 0,
                     "maxLength": 255
+                },
+                "format": {
+                    "type": {
+                        "enum": [
+                            "NUMBER",
+                            "PERCENT",
+                            "CURRENCY",
+                            "DATE",
+                            "TIME",
+                            "DATE_TIME",
+                            "UNSPECIFIED"
+                        ]
+                    }
+                },
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1
                 },
                 "decimals": {
                     "type": "integer",
@@ -152,61 +168,6 @@
             ],
             "additionalProperties": false
         },
-        "SPSS-DATE": {
-            "properties": {
-                "type": {
-                    "enum": [
-                        "DATE"
-                    ]
-                },
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 64
-                },
-                "label": {
-                    "type": "string",
-                    "minLength": 0,
-                    "maxLength": 255
-                },
-                "categories": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "code": {
-                                "type": "string",
-                                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-                            },
-                            "label": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "code",
-                            "label"
-                        ],
-                        "additionalProperties": false
-                    }
-                },
-                "missing": {
-                    "type": "object",
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/SPSS-DATE-DISCRETE"
-                        },
-                        {
-                            "$ref": "#/definitions/DATE-RANGE"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "type",
-                "name"
-            ],
-            "additionalProperties": false
-        },
         "SPSS-NUMERIC-DISCRETE": {
             "type": "object",
             "properties": {
@@ -254,30 +215,6 @@
                 "values"
             ],
             "additionalProperties": false
-        },
-        "SPSS-DATE-DISCRETE": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "DISCRETE"
-                    ]
-                },
-                "values": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-                    },
-                    "minItems": 1,
-                    "maxItems": 3,
-                    "uniqueItems": true
-                }
-            },
-            "required": [
-                "type",
-                "values"
-            ]
         },
         "NUMERIC-RANGE": {
             "type": "object",
@@ -342,7 +279,9 @@
                 },
                 "separator": {
                     "enum": [
-                        ",", ";", "\t"
+                        ",",
+                        ";",
+                        "\t"
                     ]
                 },
                 "variables": {
@@ -354,9 +293,6 @@
                                 "$ref": "#/definitions/STATA-NUMERIC"
                             },
                             {
-                                "$ref": "#/definitions/STATA-DATE"
-                            },
-                                                        {
                                 "$ref": "#/definitions/STATA-STRING"
                             }
                         ]
@@ -381,6 +317,23 @@
                     "type": "string",
                     "minLength": 0,
                     "maxLength": 255
+                },
+                "format": {
+                    "type": {
+                        "enum": [
+                            "NUMBER",
+                            "PERCENT",
+                            "CURRENCY",
+                            "DATE",
+                            "TIME",
+                            "DATE_TIME",
+                            "UNSPECIFIED"
+                        ]
+                    }
+                },
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1
                 },
                 "decimals": {
                     "type": "integer",
@@ -448,85 +401,6 @@
             ],
             "additionalProperties": false
         },
-        "STATA-DATE": {
-            "properties": {
-                "type": {
-                    "enum": [
-                        "DATE"
-                    ]
-                },
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 32
-                },
-                "label": {
-                    "type": "string",
-                    "minLength": 0,
-                    "maxLength": 255
-                },
-                "categories": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "code": {
-                                "type": "string",
-                                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-                            },
-                            "label": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "code",
-                            "label"
-                        ],
-                        "additionalProperties": false
-                    }
-                },
-                "missing": {
-                    "type": "object",
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/STATA-DATE-DISCRETE"
-                        },
-                        {
-                            "$ref": "#/definitions/DATE-RANGE"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "type",
-                "name"
-            ],
-            "additionalProperties": false
-        },
-        "STATA-DATE-DISCRETE": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "DISCRETE"
-                    ]
-                },
-                "values": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-                    },
-                    "minItems": 1,
-                    "maxItems": 26,
-                    "uniqueItems": true
-                }
-            },
-            "required": [
-                "type",
-                "values"
-            ]
-        },
         "STATA-STRING": {
             "properties": {
                 "type": {
@@ -544,7 +418,7 @@
                     "minLength": 0,
                     "maxLength": 255
                 },
-                 "categories": {
+                "categories": {
                     "type": "array",
                     "items": {
                         "type": "object",


### PR DESCRIPTION
Hi @evanmiller,

I made a first implementation to support duration in `extract_metadata`. This feature would break backward compatibility, so it is up to you to tell me if we should use a different strategy.

I use this website as a reference for the existing data types https://libguides.library.kent.edu/SPSS/DatesTime.

## Other option

As I mentioned on the PR #220, the other option would be to label the type as `NUMERIC` for both dates and durations, but then include a format field in the JSON payload that gives the format:

    TIME8 => hh:mm:ss

```json
{
   "type": "NUMERIC",
   "format": "TIME",
   "pattern": "hh:mm:ss"
}
```

Possible formats:

1. NUMBER
1. PERCENT
1. CURRENCY
1. DATE
1. TIME
1. DATE_TIME
1. UNSPECIFIED

## Note on data type handling

I added the following comment to the code:

        // All-or-nothing is probably not the best strategy for data type extraction.
        // When SPSS/STATA introduces new types, metadata extraction could fail.
        // It would be wiser to simply label the field as "UNKNOWN".

It is a philosophy I guess, but I would argue that this error should be handled further up in the stack. `extract_metadata` should be responsible to, as its name states, extracting metadata. Now if a new type is introduced, it should simply return the column as categorised instead of failing. Perhaps this new column is not important at all and does not deserve a complete failure in the extraction process.

## Style

Also, note that I haven't worked with C in a long time and I did not want to start going crazy with the refactor, but I'm pretty sure we can't have a more elegant function than this chain of `strncmp`. What would you suggest?

In Go I would have used a map of strings:

```go
  var categories = map[string]string{
    "TIME8": "DURATION",
    "DATE9": "DATE",
    // ...
  }
```