### PR TITLE
Fix incorrect ordering in StrL comparison functions

### DIFF
--- a/src/readstat_writer.c
+++ b/src/readstat_writer.c
@@ -19,10 +19,10 @@ static int readstat_compare_string_refs(const void *elem1, const void *elem2) {
     readstat_string_ref_t *ref1 = *(readstat_string_ref_t **)elem1;
     readstat_string_ref_t *ref2 = *(readstat_string_ref_t **)elem2;
 
-    if (ref1->first_v == ref2->first_v)
-        return ref1->first_o - ref2->first_o;
+    if (ref1->first_o == ref2->first_o)
+        return ref1->first_v - ref2->first_v;
 
-    return ref1->first_v - ref2->first_v;
+    return ref1->first_o - ref2->first_o;
 }
 
 readstat_string_ref_t *readstat_string_ref_init(const char *string) {

--- a/src/stata/readstat_dta_read.c
+++ b/src/stata/readstat_dta_read.c
@@ -317,10 +317,10 @@ cleanup:
 static int dta_compare_strls(const void *elem1, const void *elem2) {
     const dta_strl_t *key = (const dta_strl_t *)elem1;
     const dta_strl_t *target = *(const dta_strl_t **)elem2;
-    if (key->v == target->v)
-        return key->o - target->o;
+    if (key->o == target->o)
+        return key->v - target->v;
 
-    return key->v - target->v;
+    return key->o - target->o;
 }
 
 static dta_strl_t dta_interpret_strl_vo_bytes(dta_ctx_t *ctx, const unsigned char *vo_bytes) {


### PR DESCRIPTION
Hi @evanmiller,

While investigating an unrelated issue with stata files crashing R in haven (tidyverse/haven#600) I noticed that readstat isn't implementing StrL ordering correctly.

In the [dta spec](https://www.stata.com/help.cgi?dta#strls_gso) it says:

> 3. GSOs must appear in "ascending" order of (v,o).  Ascending order is defined as the same order as they appeared in `<data>...</data>`: ascending v for o==1, followed by ascending v for o==2, ....

The comparison function used for searching the StrL array is currently assuming that it's ordered by v then o, i.e. ascending o for v == 1, followed by ascending o for v == 2 etc. As a result the bsearch thinks that a lot of StrL references don't exist so they're missing from the imported file.

The same assumption has been made for writing (as one would expect :slightly_smiling_face:), so files written by readstat roundtrip successfully.

This PR fixes the comparison functions for reading and writing.

### Test data

I was double checking results against another R library that has an independently implemented parser and noticed that haven/readstat was missing a bunch of string values in the imported file.
For reference, the file I was using for testing was linked by the issue creator, and can be found in this repo:
https://github.com/sjkiss/ces19/raw/main/2019%20Canadian%20Election%20Study%20-%20Online%20Survey%20v1.0.dta