### PR TITLE
configure: link to m on any GNU system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AM_ICONV
 
 AC_CANONICAL_HOST
 AS_CASE([$host],
-	[*linux*|*bsd*|*mingw*|*cygwin*], [EXTRA_LIBS="-lm"],
+	[*linux*|*bsd*|*mingw*|*cygwin*|*gnu*], [EXTRA_LIBS="-lm"],
 	[EXTRA_LIBS=""])
 AC_SUBST([EXTRA_LIBS])
 


### PR DESCRIPTION
GNU-based systems use GNU libc, which provides the math functions in
a separate "m" library. Hence, unconditionally link to it on any GNU
system.