### PR TITLE
Fix unicode non-ASCII name check with unsigned char

### DIFF
--- a/src/spss/readstat_sav_write.c
+++ b/src/spss/readstat_sav_write.c
@@ -1236,7 +1236,7 @@ static readstat_error_t sav_validate_name_chars(const char *name, int unicode) {
         if (name[j] == ' ')
             return READSTAT_ERROR_NAME_CONTAINS_ILLEGAL_CHARACTER;
 
-        if ((name[j] > 0 || !unicode) && name[j] != '@' &&
+        if (((unsigned char)name[j] < 0x80 || !unicode) && name[j] != '@' &&
                 name[j] != '.' && name[j] != '_' &&
                 name[j] != '$' && name[j] != '#' &&
                 !(name[j] >= 'a' && name[j] <= 'z') &&
@@ -1246,7 +1246,7 @@ static readstat_error_t sav_validate_name_chars(const char *name, int unicode) {
         }
     }
     char first_char = name[0];
-    if ((first_char > 0 || !unicode) && first_char != '@' &&
+    if (((unsigned char)first_char < 0x80 || !unicode) && first_char != '@' &&
             !(first_char >= 'a' && first_char <= 'z') &&
             !(first_char >= 'A' && first_char <= 'Z')) {
         return READSTAT_ERROR_NAME_BEGINS_WITH_ILLEGAL_CHARACTER;

--- a/src/stata/readstat_dta_write.c
+++ b/src/stata/readstat_dta_write.c
@@ -279,7 +279,7 @@ static readstat_error_t dta_validate_name_chars(const char *name, int unicode) {
     /* TODO check Unicode class */
     int j;
     for (j=0; name[j]; j++) {
-        if ((name[j] > 0 || !unicode) && name[j] != '_' &&
+        if (((unsigned char)name[j] < 0x80 || !unicode) && name[j] != '_' &&
                 !(name[j] >= 'a' && name[j] <= 'z') &&
                 !(name[j] >= 'A' && name[j] <= 'Z') &&
                 !(name[j] >= '0' && name[j] <= '9')) {
@@ -287,7 +287,7 @@ static readstat_error_t dta_validate_name_chars(const char *name, int unicode) {
         }
     }
     char first_char = name[0];
-    if ((first_char > 0 || !unicode) && first_char != '_' &&
+    if (((unsigned char)first_char < 0x80 || !unicode) && first_char != '_' &&
             !(first_char >= 'a' && first_char <= 'z') &&
             !(first_char >= 'A' && first_char <= 'Z')) {
         return READSTAT_ERROR_NAME_BEGINS_WITH_ILLEGAL_CHARACTER;


### PR DESCRIPTION
In case 'char' is unsigned (which happens on some architectures), then
checks like `str[i] > 0` will always be true (for non-NULL characters,
of course). Since we are interested to check only for the values <= 127,
then change the check to cast the char to unsigned, so we can always
check that the value is lower than 0x80 (128).