### PR TITLE
Handle invalid multi-byte sequences in iconv encoding conversions

### DIFF
--- a/src/readstat.h
+++ b/src/readstat.h
@@ -298,6 +298,20 @@ typedef int (*readstat_value_label_handler)(const char *val_labels,
         readstat_value_t value, const char *label, void *ctx);
 typedef void (*readstat_error_handler)(const char *error_message, void *ctx);
 typedef int (*readstat_progress_handler)(double progress, void *ctx);
+typedef int (*readstat_bad_byte_handler)(char *dst, size_t dst_len,
+        const char *src, size_t src_len, int obs_index, readstat_variable_t *variable,
+        void *ctx);
+
+int readstat_bad_byte_info(char *dst, size_t dst_len, const char *src, size_t src_len,
+    int obs_index, readstat_variable_t *variable, void *ctx);
+int readstat_bad_byte_copy(char *dst, size_t dst_len, const char *src, size_t src_len,
+    int obs_index, readstat_variable_t *variable, void *ctx);
+int readstat_bad_byte_skip(char *dst, size_t dst_len, const char *src, size_t src_len,
+    int obs_index, readstat_variable_t *variable, void *ctx);
+int readstat_bad_byte_utf8(char *dst, size_t dst_len, const char *src, size_t src_len,
+    int obs_index, readstat_variable_t *variable, void *ctx);
+int readstat_bad_byte_cp1252(char *dst, size_t dst_len, const char *src, size_t src_len,
+    int obs_index, readstat_variable_t *variable, void *ctx);
 
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
@@ -342,6 +356,7 @@ typedef struct readstat_callbacks_s {
     readstat_value_label_handler   value_label;
     readstat_error_handler         error;
     readstat_progress_handler      progress;
+    readstat_bad_byte_handler      bad_byte;
 } readstat_callbacks_t;
 
 typedef struct readstat_parser_s {
@@ -365,6 +380,7 @@ readstat_error_t readstat_set_value_handler(readstat_parser_t *parser, readstat_
 readstat_error_t readstat_set_value_label_handler(readstat_parser_t *parser, readstat_value_label_handler value_label_handler);
 readstat_error_t readstat_set_error_handler(readstat_parser_t *parser, readstat_error_handler error_handler);
 readstat_error_t readstat_set_progress_handler(readstat_parser_t *parser, readstat_progress_handler progress_handler);
+readstat_error_t readstat_set_bad_byte_handler(readstat_parser_t *parser, readstat_bad_byte_handler bad_byte_handler);
 
 readstat_error_t readstat_set_open_handler(readstat_parser_t *parser, readstat_open_handler open_handler);
 readstat_error_t readstat_set_close_handler(readstat_parser_t *parser, readstat_close_handler close_handler);

--- a/src/readstat_convert.c
+++ b/src/readstat_convert.c
@@ -17,9 +17,9 @@ readstat_error_t readstat_convert(char *dst, size_t dst_len, const char *src, si
         char *dst_end = dst;
         size_t status = iconv(converter, (readstat_iconv_inbuf_t)&src, &src_len, &dst_end, &dst_left);
         if (status == (size_t)-1) {
-            if (errno == E2BIG) {
+            if (errno == E2BIG) { /* E2BIG indicates that the output buffer is not large enough */
                 return READSTAT_ERROR_CONVERT_LONG_STRING;
-            } else if (errno == EILSEQ) {
+            } else if (errno == EILSEQ) { /* EILSEQ indicates an invalid multibyte sequence */
                 return READSTAT_ERROR_CONVERT_BAD_STRING;
             } else if (errno != EINVAL) { /* EINVAL indicates improper truncation; accept it */
                 return READSTAT_ERROR_CONVERT;
@@ -34,3 +34,110 @@ readstat_error_t readstat_convert(char *dst, size_t dst_len, const char *src, si
     }
     return READSTAT_OK;
 }
+
+int readstat_bad_byte_info(char *dst, size_t dst_len, const char *src, size_t src_len, int obs_index, readstat_variable_t *variable, void *ctx) {
+    /* show information about the invalid string and exit */
+    printf("Invalid string in variable %s, row %d: \"%s\"\n", variable->name, obs_index, src);
+
+    return READSTAT_HANDLER_ABORT;
+}
+
+int readstat_bad_byte_copy(char *dst, size_t dst_len, const char *src, size_t src_len, int obs_index, readstat_variable_t *variable, void *ctx) {
+    /* copy over the string unedited and continue */
+
+    /* strip off spaces from the input because the programs use ASCII space
+     * padding even with non-ASCII encoding. */
+    while (src_len && src[src_len-1] == ' ') {
+        src_len--;
+    }
+
+    if (src_len + 1 > dst_len) {
+        return READSTAT_HANDLER_ABORT;
+    }
+
+    memcpy(dst, src, src_len);
+    dst[src_len] = '\0';
+
+    return READSTAT_HANDLER_OK;
+}
+
+int readstat_bad_byte_skip(char *dst, size_t dst_len, const char *src, size_t src_len, int obs_index, readstat_variable_t *variable, void *ctx) {
+    /* skip the invalid string */
+    dst[0] = '\0';
+
+    return READSTAT_HANDLER_OK;
+}
+
+int readstat_bad_byte_utf8(char *dst, size_t dst_len, const char *src, size_t src_len, int obs_index, readstat_variable_t *variable, void *ctx) {
+    /* treat string as utf-8 and use the unicode replacement character for any invalid bytes */
+
+    /* strip off spaces from the input because the programs use ASCII space
+     * padding even with non-ASCII encoding. */
+    while (src_len && src[src_len-1] == ' ') {
+        src_len--;
+    }
+
+    iconv_t converter = iconv_open("UTF-8", "UTF-8");
+    if (converter == (iconv_t)-1) {
+        return READSTAT_HANDLER_ABORT;
+    }
+
+    size_t dst_left = dst_len - 1;
+    char *dst_end = dst;
+    size_t src_left = src_len;
+    const char *src_end = src;
+    while (src_left > 0) {
+        size_t status = iconv(converter, (readstat_iconv_inbuf_t)&src_end, &src_left, &dst_end, &dst_left);
+        if (status == (size_t)-1) {
+            if (errno == E2BIG) { /* E2BIG indicates that the output buffer is not large enough */
+                return READSTAT_HANDLER_ABORT;
+            } else if (errno == EILSEQ) { /* EILSEQ indicates an invalid multibyte sequence */
+                if (dst_left < 3) {
+                    return READSTAT_HANDLER_ABORT;
+                }
+
+                dst_end[0] = (char) 0xEF;
+                dst_end[1] = (char) 0xBF;
+                dst_end[2] = (char) 0xBD;
+                dst_end += 3;
+                src_end += 1;
+                dst_left -= 3;
+                src_left -= 1;
+            } else if (errno != EINVAL) { /* EINVAL indicates improper truncation; accept it */
+                return READSTAT_HANDLER_ABORT;
+            } else {
+                /* finish here and accept conversion if EINVAL is returned */
+                break;
+            }
+        }
+    }
+    dst[dst_len - dst_left - 1] = '\0';
+
+    iconv_close(converter);
+    return READSTAT_HANDLER_OK;
+}
+
+int readstat_bad_byte_cp1252(char *dst, size_t dst_len, const char *src, size_t src_len, int obs_index, readstat_variable_t *variable, void *ctx) {
+    /* try converting the rest of the string as WINDOWS-1252, common encoding error */
+    while (src_len && src[src_len-1] == ' ') {
+        src_len--;
+    }
+
+    iconv_t converter = iconv_open("UTF-8", "WINDOWS-1252");
+    if (converter == (iconv_t)-1) {
+        return READSTAT_HANDLER_ABORT;
+    }
+
+    size_t dst_left = dst_len - 1;
+    char *dst_end = dst;
+    size_t status = iconv(converter, (readstat_iconv_inbuf_t)&src, &src_len, &dst_end, &dst_left);
+
+    if (status == (size_t)-1) {
+        return READSTAT_HANDLER_ABORT;
+    }
+    dst[dst_len - dst_left - 1] = '\0';
+
+    iconv_close(converter);
+    return READSTAT_HANDLER_OK;
+}
+

--- a/src/readstat_parser.c
+++ b/src/readstat_parser.c
@@ -59,6 +59,11 @@ readstat_error_t readstat_set_progress_handler(readstat_parser_t *parser, readst
     return READSTAT_OK;
 }
 
+readstat_error_t readstat_set_bad_byte_handler(readstat_parser_t *parser, readstat_bad_byte_handler bad_byte_handler) {
+    parser->handlers.bad_byte = bad_byte_handler;
+    return READSTAT_OK;
+}
+
 readstat_error_t readstat_set_fweight_handler(readstat_parser_t *parser, readstat_fweight_handler fweight_handler) {
     parser->handlers.fweight = fweight_handler;
     return READSTAT_OK;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -726,8 +726,18 @@ static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len
                 if (!ctx->variables[var_info->index]->skip) {
                     retval = readstat_convert(ctx->utf8_string, ctx->utf8_string_len, 
                             ctx->raw_string, raw_str_used, ctx->converter);
-                    if (retval != READSTAT_OK)
+                    if (retval == READSTAT_ERROR_CONVERT_BAD_STRING) {
+                        if (!ctx->handle.bad_byte) {
+                            goto done;
+                        } else if (ctx->handle.bad_byte(ctx->utf8_string, ctx->utf8_string_len,
+                                ctx->raw_string, raw_str_used, ctx->current_row,
+                                ctx->variables[var_info->index], ctx->user_ctx) != READSTAT_HANDLER_OK) {
+                            retval = READSTAT_ERROR_USER_ABORT;
+                            goto done;
+                        }
+                    } else if (retval != READSTAT_OK) {
                         goto done;
+                    }
                     value.v.string_value = ctx->utf8_string;
                     if (ctx->handle.value(ctx->current_row, ctx->variables[var_info->index],
                                 value, ctx->user_ctx) != READSTAT_HANDLER_OK) {


### PR DESCRIPTION
Hi @evanmiller,

This PR is another go at #252 (cc tidyverse/haven#615).

As suggested I've reworked the bad byte handler so it's called from surrounding code when a conversion fails instead of processing bytes inside `readstat_convert()`. I've implemented the handler in the string conversion code in `sav_process_row()` as an example, and there are a handful of bad byte handlers in readstat_convert.c.

The handler signature includes the `src` and `dst` variables from `readstat_convert()` as well as the observation index and variable object for error logging.

Thanks!