### PR TITLE
Fix off by one error in v,o indexing for string refs

### DIFF
--- a/src/readstat_writer.c
+++ b/src/readstat_writer.c
@@ -604,8 +604,8 @@ readstat_error_t readstat_insert_string_ref(readstat_writer_t *writer, const rea
         return READSTAT_ERROR_STRING_REFS_NOT_SUPPORTED;
 
     if (ref && ref->first_o == -1 && ref->first_v == -1) {
-        ref->first_o = writer->current_row;
-        ref->first_v = variable->index;
+        ref->first_o = writer->current_row + 1;
+        ref->first_v = variable->index + 1;
     }
 
     return writer->callbacks.write_string_ref(&writer->row[variable->offset], variable, ref);


### PR DESCRIPTION
This PR modifies `readstat_insert_string_ref()` to use 1 based indexing for variable and observation indexes in line with Stata's behaviour.  Closes #269.