### PR TITLE
Fix SAS catalog parsing failure when formats have no labels

### DIFF
--- a/src/sas/readstat_sas7bcat_read.c
+++ b/src/sas/readstat_sas7bcat_read.c
@@ -182,6 +182,9 @@ static readstat_error_t sas7bcat_parse_block(const char *data, size_t data_size,
     if (data_size < payload_offset + pad)
         goto cleanup;
 
+    if (label_count_used == 0)
+        goto cleanup;
+
     if ((retval = sas7bcat_parse_value_labels(&data[payload_offset+pad], data_size - payload_offset - pad,
                     label_count_used, label_count_capacity, name, ctx)) != READSTAT_OK)
         goto cleanup;


### PR DESCRIPTION
This PR fixes an "Unable to allocate memory" error when attempting to parse sas7bcat files containing a format with no value labels.

This fixes a couple of issues reported in haven:
tidyverse/haven#653
tidyverse/haven#705

Thanks!