### PR TITLE
Check for long names in u64 SAS catalog files

### DIFF
--- a/src/sas/readstat_sas7bcat_read.c
+++ b/src/sas/readstat_sas7bcat_read.c
@@ -169,7 +169,7 @@ static readstat_error_t sas7bcat_parse_block(const char *data, size_t data_size,
         pad += 16;
     }
 
-    if ((data[2] & 0x80) && !ctx->u64) { // has long name
+    if (((data[2] & 0x80) && !ctx->u64) || ((data[2] & 0x20) && ctx->u64)) { // has long name
         if (data_size < payload_offset + pad + 32)
             goto cleanup;
 


### PR DESCRIPTION
This PR adds support for long names in u64 SAS catalog files. It looks like the bit flag for u64 catalog files is different to others - I'm only working off a single example file so possibly a bit of a long shot but there's a single bit difference (B8 for long names vs 98 for short names in the example file) so it looks like 0x20 is the correct bit mask, and this loads the catalog file successfully.

From tidyverse/haven#680 - example catalog file at [sas_catalog_file.zip](https://github.com/tidyverse/haven/files/9062177/sas_catalog_file.zip)

Thanks!