### PR TITLE
Fix excess whitespace in SAS catalog long format names

### DIFF
--- a/src/sas/readstat_sas7bcat_read.c
+++ b/src/sas/readstat_sas7bcat_read.c
@@ -176,6 +176,15 @@ static readstat_error_t sas7bcat_parse_block(const char *data, size_t data_size,
         retval = readstat_convert(name, sizeof(name), &data[payload_offset+pad], 32, ctx->converter);
         if (retval != READSTAT_OK)
             goto cleanup;
+
+        // Where long names are shorter than 8 characters they may still have
+        // trailing spaces, so we need to do an extra space removal just in case
+        size_t name_len = strlen(name);
+        while (name_len && name[name_len-1] == ' ') {
+            name_len--;
+        }
+        name[name_len] = '\0';
+
         pad += 32;
     }
 


### PR DESCRIPTION
In SAS catalog files there are sometimes formats that have a long name field but the format name is less than 8 characters (i.e. where the format name could fit into the short name field but it still creates a long name for some reason). Rather than storing the name with space padding up to 32 bytes like a usual long name, it is stored in 8 bytes with space padding and has null bytes for the remaining 24 bytes.

`readstat_convert()` usually trims trailing spaces, but in this case it doesn't because of the trailing null bytes.
https://github.com/WizardMac/ReadStat/blob/75dce86dc31cd588486cdca5bbccc720206cbf2c/src/sas/readstat_sas7bcat_read.c#L172-L180

As a result ReadStat keeps the whitespace at the end of the format names, so the formats aren't applied correctly to the data. This PR adds an extra round of space trimming for long format names to clean these up.

From tidyverse/haven#529 - example catalog file [format17.sas7bcat](https://github.com/jacciz/haven_label/raw/master/format17.sas7bcat)

Thanks!