### PR TITLE
Add (void) to remove -Wstrict-prototypes warnings

### DIFF
--- a/src/bin/readstat.c
+++ b/src/bin/readstat.c
@@ -154,7 +154,7 @@ readstat_error_t parse_file(readstat_parser_t *parser, const char *input_filenam
     return error;
 }
 
-static void print_version() {
+static void print_version(void) {
     fprintf(stdout, "ReadStat version " READSTAT_VERSION "\n");
 }
 

--- a/src/readstat_bits.c
+++ b/src/readstat_bits.c
@@ -8,7 +8,7 @@
 
 #include "readstat_bits.h"
 
-int machine_is_little_endian() {
+int machine_is_little_endian(void) {
     int test_byte_order = 1;
     return ((char *)&test_byte_order)[0];
 }

--- a/src/readstat_parser.c
+++ b/src/readstat_parser.c
@@ -3,7 +3,7 @@
 #include "readstat.h"
 #include "readstat_io_unistd.h"
 
-readstat_parser_t *readstat_parser_init() {
+readstat_parser_t *readstat_parser_init(void) {
     readstat_parser_t *parser = calloc(1, sizeof(readstat_parser_t));
     parser->io = calloc(1, sizeof(readstat_io_t));
     if (unistd_io_init(parser) != READSTAT_OK) {

--- a/src/readstat_variable.c
+++ b/src/readstat_variable.c
@@ -5,7 +5,7 @@
 static readstat_value_t make_blank_value(void);
 static readstat_value_t make_double_value(double dval);
 
-static readstat_value_t make_blank_value() {
+static readstat_value_t make_blank_value(void) {
     readstat_value_t value = { .is_system_missing = 1, .v = { .double_value = NAN }, .type = READSTAT_TYPE_DOUBLE };
     return value;
 }

--- a/src/readstat_writer.c
+++ b/src/readstat_writer.c
@@ -35,7 +35,7 @@ readstat_string_ref_t *readstat_string_ref_init(const char *string) {
     return ref;
 }
 
-readstat_writer_t *readstat_writer_init() {
+readstat_writer_t *readstat_writer_init(void) {
     readstat_writer_t *writer = calloc(1, sizeof(readstat_writer_t));
 
     writer->variables = calloc(VARIABLES_INITIAL_CAPACITY, sizeof(readstat_variable_t *));

--- a/src/sas/ieee.c
+++ b/src/sas/ieee.c
@@ -366,7 +366,7 @@ void ieee2xpt(unsigned char *ieee, unsigned char *xport) {
     shift = (int)
         (ieee_exp = (int)(((ieee1 >> 16) & 0x7ff0) >> 4) - 1023)
         & 3;
-    /* the ieee format has an implied "1" immdeiately to the left */
+    /* the ieee format has an implied "1" immediately to the left */
     /* of the binary point. Show it in here. */
     xport1 |= 0x00100000;
     if (shift)
@@ -377,7 +377,7 @@ void ieee2xpt(unsigned char *ieee, unsigned char *xport) {
         /* from the lower half that would have been shifted in (if */
         /* we could shift a double). The shift count can never */
         /* exceed 3, so all we care about are the high order 3 */
-        /* bits. We don't want sign extention so make sure it's an */
+        /* bits. We don't want sign extension so make sure it's an */
         /* unsigned char. We'll shift either5, 6, or 7 places to */
         /* keep 3, 2, or 1 bits. After that, shift the second half */
         /* of the number the right number of places. We always get */
@@ -391,9 +391,9 @@ void ieee2xpt(unsigned char *ieee, unsigned char *xport) {
 
     /* Now set the ibm exponent and the sign of the fraction. The */
     /* power of 2 ieee exponent must be divided by 4 and made */
-    /* excess 64 (we add 65 here because of the poisition of the */
+    /* excess 64 (we add 65 here because of the position of the */
     /* fraction bits, essentially 4 positions lower than they */
-    /* should be so we incrment the ibm exponent). */
+    /* should be so we increment the ibm exponent). */
 
     xport1 |=
 

--- a/src/sas/ieee.c
+++ b/src/sas/ieee.c
@@ -96,7 +96,7 @@ int cnxptiee(const void *from_bytes, int fromtype, void *to_bytes, int totype)
     return(0);
 }
 
-int get_native() {
+int get_native(void) {
     static unsigned char float_reps[][8] = {
         {0x41,0x10,0x00,0x00,0x00,0x00,0x00,0x00},
         {0x3f,0xf0,0x00,0x00,0x00,0x00,0x00,0x00},
@@ -377,7 +377,7 @@ void ieee2xpt(unsigned char *ieee, unsigned char *xport) {
         /* from the lower half that would have been shifted in (if */
         /* we could shift a double). The shift count can never */
         /* exceed 3, so all we care about are the high order 3 */
-        /* bits. We don't want sign extension so make sure it's an */
+        /* bits. We don't want sign extention so make sure it's an */
         /* unsigned char. We'll shift either5, 6, or 7 places to */
         /* keep 3, 2, or 1 bits. After that, shift the second half */
         /* of the number the right number of places. We always get */
@@ -391,9 +391,9 @@ void ieee2xpt(unsigned char *ieee, unsigned char *xport) {
 
     /* Now set the ibm exponent and the sign of the fraction. The */
     /* power of 2 ieee exponent must be divided by 4 and made */
-    /* excess 64 (we add 65 here because of the position of the */
+    /* excess 64 (we add 65 here because of the poisition of the */
     /* fraction bits, essentially 4 positions lower than they */
-    /* should be so we increment the ibm exponent). */
+    /* should be so we incrment the ibm exponent). */
 
     xport1 |=
 

--- a/src/sas/readstat_sas.c
+++ b/src/sas/readstat_sas.c
@@ -120,7 +120,7 @@ static readstat_charset_entry_t _charset_table[] = {
     { .code = 248,   .name = "SHIFT_JISX0213" },
 };
 
-static time_t sas_epoch() {
+static time_t sas_epoch(void) {
     return - 3653 * 86400; // seconds between 01-01-1960 and 01-01-1970
 }
 

--- a/src/sas/readstat_xport_read.c
+++ b/src/sas/readstat_xport_read.c
@@ -45,7 +45,7 @@ static readstat_error_t xport_update_progress(xport_ctx_t *ctx) {
     return io->update(ctx->file_size, ctx->handle.progress, ctx->user_ctx, io->io_ctx);
 }
 
-static xport_ctx_t *xport_ctx_init() {
+static xport_ctx_t *xport_ctx_init(void) {
     xport_ctx_t *ctx = calloc(1, sizeof(xport_ctx_t));
     return ctx;
 }

--- a/src/sas/readstat_xport_write.c
+++ b/src/sas/readstat_xport_write.c
@@ -10,7 +10,7 @@
 #include "readstat_xport_parse_format.h"
 #include "ieee.h"
 
-#define XPORT_DEFAULT_VERISON   8
+#define XPORT_DEFAULT_VERSION   8
 #define RECORD_LEN 80
 
 #if defined _MSC_VER
@@ -531,7 +531,7 @@ static readstat_error_t xport_metadata_ok(void *writer_ctx) {
 readstat_error_t readstat_begin_writing_xport(readstat_writer_t *writer, void *user_ctx, long row_count) {
 
     if (writer->version == 0)
-        writer->version = XPORT_DEFAULT_VERISON;
+        writer->version = XPORT_DEFAULT_VERSION;
 
     writer->callbacks.metadata_ok = &xport_metadata_ok;
     writer->callbacks.write_int8 = &xport_write_int8;

--- a/src/sas/readstat_xport_write.c
+++ b/src/sas/readstat_xport_write.c
@@ -10,7 +10,7 @@
 #include "readstat_xport_parse_format.h"
 #include "ieee.h"
 
-#define XPORT_DEFAULT_VERSION   8
+#define XPORT_DEFAULT_VERISON   8
 #define RECORD_LEN 80
 
 #if defined _MSC_VER
@@ -531,7 +531,7 @@ static readstat_error_t xport_metadata_ok(void *writer_ctx) {
 readstat_error_t readstat_begin_writing_xport(readstat_writer_t *writer, void *user_ctx, long row_count) {
 
     if (writer->version == 0)
-        writer->version = XPORT_DEFAULT_VERSION;
+        writer->version = XPORT_DEFAULT_VERISON;
 
     writer->callbacks.metadata_ok = &xport_metadata_ok;
     writer->callbacks.write_int8 = &xport_write_int8;

--- a/src/spss/readstat_por.c
+++ b/src/spss/readstat_por.c
@@ -64,7 +64,7 @@ uint16_t por_unicode_lookup[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0 };
 
-por_ctx_t *por_ctx_init() {
+por_ctx_t *por_ctx_init(void) {
     por_ctx_t *ctx = calloc(1, sizeof(por_ctx_t));
 
     ctx->space = ' ';

--- a/src/spss/readstat_por_write.c
+++ b/src/spss/readstat_por_write.c
@@ -167,7 +167,7 @@ static readstat_error_t por_write_string_field(readstat_writer_t *writer, por_wr
     return por_write_string_field_n(writer, ctx, string, strlen(string));
 }
 
-static por_write_ctx_t *por_write_ctx_init() {
+static por_write_ctx_t *por_write_ctx_init(void) {
     por_write_ctx_t *ctx = calloc(1, sizeof(por_write_ctx_t));
     uint16_t max_unicode = 0;
     int i;


### PR DESCRIPTION
This expands on https://github.com/WizardMac/ReadStat/commit/5ad80040b94b667e2fef74e9b8d865f142fec820

Because just building Readstat on macos with XCode 14.3 leads to a whole lot more of those warnings and with this PR they should be silenced properly.