### PR TITLE
Fix use after free

### DIFF
--- a/src/bin/readstat.c
+++ b/src/bin/readstat.c
@@ -397,8 +397,6 @@ cleanup:
         module->finish(rs_ctx->module_ctx);
     }
 
-    free(rs_ctx);
-
     if (error != READSTAT_OK) {
         if (file_exists) {
             fprintf(stderr, "Error opening %s: File exists (Use -f to overwrite)\n", output_filename);
@@ -406,8 +404,13 @@ cleanup:
             fprintf(stderr, "Error processing %s: %s\n", rs_ctx->error_filename, readstat_error_message(error));
             unlink(output_filename);
         }
+
+	free(rs_ctx);
+
         return 1;
     }
+
+    free(rs_ctx);
 
     return 0;
 }


### PR DESCRIPTION
free(rs_ctx) is called before last use of rs_ctx. 