### PR TITLE
handles metadata timezone differences in sas

### DIFF
--- a/src/sas/readstat_sas.c
+++ b/src/sas/readstat_sas.c
@@ -124,7 +124,8 @@ static time_t sas_epoch(void) {
     return - 3653 * 86400; // seconds between 01-01-1960 and 01-01-1970
 }
 
-static time_t sas_convert_time(double time, time_t epoch) {
+static time_t sas_convert_time(double time, double time_diff, time_t epoch) {
+    time -= time_diff;
     time += epoch;
     if (isnan(time))
         return 0;
@@ -212,7 +213,7 @@ readstat_error_t sas_read_header(readstat_io_t *io, sas_header_info_t *hinfo,
         goto cleanup;
     }
 
-    double creation_time, modification_time;
+    double creation_time, modification_time, creation_time_diff, modification_time_diff;
 
     if (io->read(&creation_time, sizeof(double), io->io_ctx) < sizeof(double)) {
         retval = READSTAT_ERROR_READ;
@@ -228,13 +229,27 @@ readstat_error_t sas_read_header(readstat_io_t *io, sas_header_info_t *hinfo,
     if (bswap)
         modification_time = byteswap_double(modification_time);
 
-    hinfo->creation_time = sas_convert_time(creation_time, epoch);
-    hinfo->modification_time = sas_convert_time(modification_time, epoch);
-
-    if (io->seek(16, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
-        retval = READSTAT_ERROR_SEEK;
+    if (io->read(&creation_time_diff, sizeof(double), io->io_ctx) < sizeof(double)) {
+        retval = READSTAT_ERROR_READ;
         goto cleanup;
     }
+    if (bswap)
+        creation_time_diff = byteswap_double(creation_time_diff);
+    
+    if (io->read(&modification_time_diff, sizeof(double), io->io_ctx) < sizeof(double)) {
+        retval = READSTAT_ERROR_READ;
+        goto cleanup;
+    }
+    if (bswap)
+        modification_time_diff = byteswap_double(modification_time_diff);
+    
+    hinfo->creation_time = sas_convert_time(creation_time, creation_time_diff, epoch);
+    hinfo->modification_time = sas_convert_time(modification_time, modification_time_diff, epoch);
+
+    // if (io->seek(16, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
+    //     retval = READSTAT_ERROR_SEEK;
+    //     goto cleanup;
+    // }
 
     uint32_t header_size, page_size;
 

--- a/src/sas/readstat_sas.c
+++ b/src/sas/readstat_sas.c
@@ -246,11 +246,6 @@ readstat_error_t sas_read_header(readstat_io_t *io, sas_header_info_t *hinfo,
     hinfo->creation_time = sas_convert_time(creation_time, creation_time_diff, epoch);
     hinfo->modification_time = sas_convert_time(modification_time, modification_time_diff, epoch);
 
-    // if (io->seek(16, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
-    //     retval = READSTAT_ERROR_SEEK;
-    //     goto cleanup;
-    // }
-
     uint32_t header_size, page_size;
 
     if (io->read(&header_size, sizeof(uint32_t), io->io_ctx) < sizeof(uint32_t)) {


### PR DESCRIPTION
Dear maintainers and reviewers,

- Previously, it is known that dataset creation/modification time is stored in the header of a SAS dataset. It is assumed that these 2 datetimes are saved as UTC timezone.
- After an investigation, it turns out that SAS will store local time instead of UTC time in the header under some circumstances. 

To address this:

1. Found the place where SAS store the timezone difference
2. Convert local time back to UTC time

This PR will:

1. Reads timezone difference (which is stored just after the creation/modification time place)
2. Convert local time to UTC time: 
    - Timezone difference is store as seconds between UTC and local time with sign. E.g., Eastern Standard time (UTC-5) is -18000.
    - So, local time minus timezone difference is UTC time (`local_time = UTC + diff`).