### PR TITLE
Fix a buffer overflow

### DIFF
--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -717,7 +717,7 @@ static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len
             }
             if (++offset == col_info->width) {
                 if (++segment_offset < var_info->n_segments) {
-                    raw_str_used--;
+                    if (raw_str_used > 0) raw_str_used--;
                 }
                 offset = 0;
                 col++;


### PR DESCRIPTION
It happens if raw_str_used underflows and ends up a very large number, which is then used as the size of a string.

Closes #285.