### PR TITLE
Add functionality for MR metadata reading from SAV

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ libreadstat_la_SOURCES = \
 	src/spss/readstat_sav_compress.c \
 	src/spss/readstat_sav_parse.c \
 	src/spss/readstat_sav_parse_timestamp.c \
+	src/spss/readstat_sav_parse_mr_name.c \
 	src/spss/readstat_sav_read.c \
 	src/spss/readstat_sav_write.c \
 	src/spss/readstat_spss.c \
@@ -103,6 +104,7 @@ noinst_HEADERS = \
        src/spss/readstat_sav_compress.h \
        src/spss/readstat_sav_parse.h \
        src/spss/readstat_sav_parse_timestamp.h \
+       src/spss/readstat_sav_parse_mr_name.h \
        src/spss/readstat_spss.h \
        src/spss/readstat_spss_parse.h \
        src/spss/readstat_zsav_compress.h \

--- a/VS17/ReadStat.vcxproj
+++ b/VS17/ReadStat.vcxproj
@@ -215,6 +215,7 @@
     <ClCompile Include="..\src\spss\readstat_sav_compress.c" />
     <ClCompile Include="..\src\spss\readstat_sav_parse.c" />
     <ClCompile Include="..\src\spss\readstat_sav_parse_timestamp.c" />
+    <ClCompile Include="..\src\spss\readstat_sav_parse_mr_name.c" />
     <ClCompile Include="..\src\spss\readstat_sav_read.c" />
     <ClCompile Include="..\src\spss\readstat_sav_write.c" />
     <ClCompile Include="..\src\spss\readstat_spss.c" />
@@ -251,6 +252,7 @@
     <ClInclude Include="..\src\spss\readstat_sav_compress.h" />
     <ClInclude Include="..\src\spss\readstat_sav_parse.h" />
     <ClInclude Include="..\src\spss\readstat_sav_parse_timestamp.h" />
+    <ClInclude Include="..\src\spss\readstat_sav_parse_mr_name.h" />
     <ClInclude Include="..\src\spss\readstat_spss.h" />
     <ClInclude Include="..\src\spss\readstat_spss_parse.h" />
     <ClInclude Include="..\src\spss\readstat_zsav_compress.h" />

--- a/VS17/ReadStat.vcxproj.filters
+++ b/VS17/ReadStat.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="..\src\spss\readstat_sav_parse_timestamp.c">
       <Filter>Source Files\spss</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\spss\readstat_sav_parse_mr_name.c">
+      <Filter>Source Files\spss</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\spss\readstat_sav_read.c">
       <Filter>Source Files\spss</Filter>
     </ClCompile>
@@ -216,6 +219,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\spss\readstat_sav_parse_timestamp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\spss\readstat_sav_parse_mr_name.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\spss\readstat_spss.h">

--- a/src/readstat.h
+++ b/src/readstat.h
@@ -104,7 +104,8 @@ typedef enum readstat_error_e {
     READSTAT_ERROR_TOO_FEW_COLUMNS,
     READSTAT_ERROR_TOO_MANY_COLUMNS,
     READSTAT_ERROR_NAME_IS_ZERO_LENGTH,
-    READSTAT_ERROR_BAD_TIMESTAMP_VALUE
+    READSTAT_ERROR_BAD_TIMESTAMP_VALUE,
+    READSTAT_ERROR_BAD_MR_STRING
 } readstat_error_t;
 
 const char *readstat_error_message(readstat_error_t error_code);

--- a/src/readstat.h
+++ b/src/readstat.h
@@ -109,6 +109,16 @@ typedef enum readstat_error_e {
 
 const char *readstat_error_message(readstat_error_t error_code);
 
+typedef struct mr_set_s {
+    char   type;
+    char  *name;
+    char  *label;
+    int    is_dichotomy;
+    int    counted_value;
+    char **subvariables;
+    int    num_subvars;
+} mr_set_t;
+
 typedef struct readstat_metadata_s {
     int64_t     row_count;
     int64_t     var_count;
@@ -121,6 +131,8 @@ typedef struct readstat_metadata_s {
     const char *file_label;
     const char *file_encoding;
     unsigned int is64bit:1;
+    size_t multiple_response_sets_length;
+    mr_set_t *mr_sets;
 } readstat_metadata_t;
 
 /* If the row count is unknown (e.g. it's an XPORT or POR file, or an SAV
@@ -138,6 +150,8 @@ readstat_endian_t readstat_get_endianness(readstat_metadata_t *metadata);
 const char *readstat_get_table_name(readstat_metadata_t *metadata);
 const char *readstat_get_file_label(readstat_metadata_t *metadata);
 const char *readstat_get_file_encoding(readstat_metadata_t *metadata);
+const mr_set_t *readstat_get_mr_sets(readstat_metadata_t *metadata);
+size_t readstat_get_multiple_response_sets_length(readstat_metadata_t *metadata);
 
 typedef struct readstat_value_s {
     union {

--- a/src/readstat.h
+++ b/src/readstat.h
@@ -151,7 +151,7 @@ readstat_endian_t readstat_get_endianness(readstat_metadata_t *metadata);
 const char *readstat_get_table_name(readstat_metadata_t *metadata);
 const char *readstat_get_file_label(readstat_metadata_t *metadata);
 const char *readstat_get_file_encoding(readstat_metadata_t *metadata);
-const mr_set_t *readstat_get_mr_sets(readstat_metadata_t *metadata);
+const mr_set_t *readstat_get_multiple_response_sets(readstat_metadata_t *metadata);
 size_t readstat_get_multiple_response_sets_length(readstat_metadata_t *metadata);
 
 typedef struct readstat_value_s {

--- a/src/readstat_metadata.c
+++ b/src/readstat_metadata.c
@@ -43,3 +43,11 @@ const char *readstat_get_file_encoding(readstat_metadata_t *metadata) {
 const char *readstat_get_table_name(readstat_metadata_t *metadata) {
     return metadata->table_name;
 }
+
+size_t readstat_get_multiple_response_sets_length(readstat_metadata_t *metadata) {
+    return metadata->multiple_response_sets_length;
+}
+
+const mr_set_t *readstat_get_mr_sets(readstat_metadata_t *metadata) {
+    return metadata->mr_sets;
+}

--- a/src/readstat_metadata.c
+++ b/src/readstat_metadata.c
@@ -48,6 +48,6 @@ size_t readstat_get_multiple_response_sets_length(readstat_metadata_t *metadata)
     return metadata->multiple_response_sets_length;
 }
 
-const mr_set_t *readstat_get_mr_sets(readstat_metadata_t *metadata) {
+const mr_set_t *readstat_get_multiple_response_sets(readstat_metadata_t *metadata) {
     return metadata->mr_sets;
 }

--- a/src/spss/readstat_sav.c
+++ b/src/spss/readstat_sav.c
@@ -59,6 +59,8 @@ sav_ctx_t *sav_ctx_init(sav_file_header_record_t *header, readstat_io_t *io) {
         return NULL;
     }
 
+    ctx->mr_sets = NULL;
+
     ctx->io = io;
     
     return ctx;
@@ -90,6 +92,7 @@ void sav_ctx_free(sav_ctx_t *ctx) {
         free(ctx->variable_display_values);
     }
     if (ctx->mr_sets) {
+        fflush(stderr);
         for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
             if (ctx->mr_sets[i].name) {
                 free(ctx->mr_sets[i].name);
@@ -98,10 +101,11 @@ void sav_ctx_free(sav_ctx_t *ctx) {
                 free(ctx->mr_sets[i].label);
             }
             if (ctx->mr_sets[i].subvariables) {
-                // No need to free each subvariable, as they've been updated in the
-                // postprocesing, just before dealin with metadata. Each subvariable was
-                // pointing to the version in long names from var_info. The var_info is
-                // freed above, so each particular subvariable pointer is freed as well.
+                for (size_t j = 0; j < ctx->mr_sets[i].num_subvars; j++) {
+                    if (ctx->mr_sets[i].subvariables[j]) {
+                        free(ctx->mr_sets[i].subvariables[j]);
+                    }
+                }
                 free(ctx->mr_sets[i].subvariables);
             }
         }

--- a/src/spss/readstat_sav.c
+++ b/src/spss/readstat_sav.c
@@ -91,25 +91,26 @@ void sav_ctx_free(sav_ctx_t *ctx) {
     if (ctx->variable_display_values) {
         free(ctx->variable_display_values);
     }
-    if (ctx->mr_sets) {
-        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
-            if (ctx->mr_sets[i].name) {
-                free(ctx->mr_sets[i].name);
-            }
-            if (ctx->mr_sets[i].label) {
-                free(ctx->mr_sets[i].label);
-            }
-            if (ctx->mr_sets[i].subvariables) {
-                for (size_t j = 0; j < ctx->mr_sets[i].num_subvars; j++) {
-                    if (ctx->mr_sets[i].subvariables[j]) {
-                        free(ctx->mr_sets[i].subvariables[j]);
-                    }
-                }
-                free(ctx->mr_sets[i].subvariables);
-            }
-        }
-        free(ctx->mr_sets);
-    }
+    // Hatchet!!
+    // if (ctx->mr_sets) {
+    //     for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+    //         if (ctx->mr_sets[i].name) {
+    //             free(ctx->mr_sets[i].name);
+    //         }
+    //         if (ctx->mr_sets[i].label) {
+    //             free(ctx->mr_sets[i].label);
+    //         }
+    //         if (ctx->mr_sets[i].subvariables) {
+    //             for (size_t j = 0; j < ctx->mr_sets[i].num_subvars; j++) {
+    //                 if (ctx->mr_sets[i].subvariables[j]) {
+    //                     free(ctx->mr_sets[i].subvariables[j]);
+    //                 }
+    //             }
+    //             free(ctx->mr_sets[i].subvariables);
+    //         }
+    //     }
+    //     free(ctx->mr_sets);
+    // }
     free(ctx);
 }
 

--- a/src/spss/readstat_sav.c
+++ b/src/spss/readstat_sav.c
@@ -91,26 +91,25 @@ void sav_ctx_free(sav_ctx_t *ctx) {
     if (ctx->variable_display_values) {
         free(ctx->variable_display_values);
     }
-    // Hatchet!!
-    // if (ctx->mr_sets) {
-    //     for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
-    //         if (ctx->mr_sets[i].name) {
-    //             free(ctx->mr_sets[i].name);
-    //         }
-    //         if (ctx->mr_sets[i].label) {
-    //             free(ctx->mr_sets[i].label);
-    //         }
-    //         if (ctx->mr_sets[i].subvariables) {
-    //             for (size_t j = 0; j < ctx->mr_sets[i].num_subvars; j++) {
-    //                 if (ctx->mr_sets[i].subvariables[j]) {
-    //                     free(ctx->mr_sets[i].subvariables[j]);
-    //                 }
-    //             }
-    //             free(ctx->mr_sets[i].subvariables);
-    //         }
-    //     }
-    //     free(ctx->mr_sets);
-    // }
+    if (ctx->mr_sets) {
+        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+            if (ctx->mr_sets[i].name) {
+                free(ctx->mr_sets[i].name);
+            }
+            if (ctx->mr_sets[i].label) {
+                free(ctx->mr_sets[i].label);
+            }
+            if (ctx->mr_sets[i].subvariables) {
+                for (size_t j = 0; j < ctx->mr_sets[i].num_subvars; j++) {
+                    if (ctx->mr_sets[i].subvariables[j]) {
+                        free(ctx->mr_sets[i].subvariables[j]);
+                    }
+                }
+                free(ctx->mr_sets[i].subvariables);
+            }
+        }
+        free(ctx->mr_sets);
+    }
     free(ctx);
 }
 

--- a/src/spss/readstat_sav.c
+++ b/src/spss/readstat_sav.c
@@ -92,7 +92,6 @@ void sav_ctx_free(sav_ctx_t *ctx) {
         free(ctx->variable_display_values);
     }
     if (ctx->mr_sets) {
-        fflush(stderr);
         for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
             if (ctx->mr_sets[i].name) {
                 free(ctx->mr_sets[i].name);

--- a/src/spss/readstat_sav.c
+++ b/src/spss/readstat_sav.c
@@ -89,6 +89,24 @@ void sav_ctx_free(sav_ctx_t *ctx) {
     if (ctx->variable_display_values) {
         free(ctx->variable_display_values);
     }
+    if (ctx->mr_sets) {
+        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+            if (ctx->mr_sets[i].name) {
+                free(ctx->mr_sets[i].name);
+            }
+            if (ctx->mr_sets[i].label) {
+                free(ctx->mr_sets[i].label);
+            }
+            if (ctx->mr_sets[i].subvariables) {
+                // No need to free each subvariable, as they've been updated in the
+                // postprocesing, just before dealin with metadata. Each subvariable was
+                // pointing to the version in long names from var_info. The var_info is
+                // freed above, so each particular subvariable pointer is freed as well.
+                free(ctx->mr_sets[i].subvariables);
+            }
+        }
+        free(ctx->mr_sets);
+    }
     free(ctx);
 }
 

--- a/src/spss/readstat_sav.h
+++ b/src/spss/readstat_sav.h
@@ -3,6 +3,7 @@
 //
 
 #include "readstat_spss.h"
+#include "../readstat.h"
 
 #pragma pack(push, 1)
 
@@ -100,6 +101,9 @@ typedef struct sav_ctx_s {
     uint64_t       lowest_double;
     uint64_t       highest_double;
 
+    size_t         multiple_response_sets_length;
+    mr_set_t      *mr_sets;
+
     double         bias;
     int            format_version;
 
@@ -117,6 +121,7 @@ typedef struct sav_ctx_s {
 
 #define SAV_RECORD_SUBTYPE_INTEGER_INFO       3
 #define SAV_RECORD_SUBTYPE_FP_INFO            4
+#define SAV_RECORD_SUBTYPE_MULTIPLE_RESPONSE_SETS 7
 #define SAV_RECORD_SUBTYPE_PRODUCT_INFO      10
 #define SAV_RECORD_SUBTYPE_VAR_DISPLAY       11
 #define SAV_RECORD_SUBTYPE_LONG_VAR_NAME     13

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -5,21 +5,20 @@
 #include <stdlib.h>
 #include "../readstat.h"
 #include "../readstat_malloc.h"
-#include "readstat_sav_parse_mr_name.h"
 
 
-#line 12 "./src/spss/readstat_sav_parse_mr_name.c"
-static const char _parse_multiple_response_actions[] = {
+#line 11 "./src/spss/readstat_sav_parse_mr_name.c"
+static const char _mr_extractor_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	3, 1, 4
 };
 
-static const char _parse_multiple_response_key_offsets[] = {
+static const char _mr_extractor_key_offsets[] = {
 	0, 0, 7, 15, 17, 20, 22, 25, 
 	33, 44
 };
 
-static const char _parse_multiple_response_trans_keys[] = {
+static const char _mr_extractor_trans_keys[] = {
 	95, 48, 57, 65, 90, 97, 122, 61, 
 	95, 48, 57, 65, 90, 97, 122, 67, 
 	68, 32, 48, 57, 48, 57, 32, 48, 
@@ -29,22 +28,22 @@ static const char _parse_multiple_response_trans_keys[] = {
 	90, 97, 122, 0
 };
 
-static const char _parse_multiple_response_single_lengths[] = {
+static const char _mr_extractor_single_lengths[] = {
 	0, 1, 2, 0, 1, 0, 1, 2, 
 	3, 1
 };
 
-static const char _parse_multiple_response_range_lengths[] = {
+static const char _mr_extractor_range_lengths[] = {
 	0, 3, 3, 1, 1, 1, 1, 3, 
 	4, 3
 };
 
-static const char _parse_multiple_response_index_offsets[] = {
+static const char _mr_extractor_index_offsets[] = {
 	0, 0, 5, 11, 13, 16, 18, 21, 
 	27, 35
 };
 
-static const char _parse_multiple_response_indicies[] = {
+static const char _mr_extractor_indicies[] = {
 	0, 0, 0, 0, 1, 2, 0, 0, 
 	0, 0, 1, 3, 1, 4, 5, 1, 
 	6, 1, 7, 6, 1, 8, 9, 9, 
@@ -53,23 +52,22 @@ static const char _parse_multiple_response_indicies[] = {
 	0
 };
 
-static const char _parse_multiple_response_trans_targs[] = {
+static const char _mr_extractor_trans_targs[] = {
 	2, 0, 3, 4, 5, 4, 6, 7, 
 	7, 8, 9
 };
 
-static const char _parse_multiple_response_trans_actions[] = {
+static const char _mr_extractor_trans_actions[] = {
 	0, 0, 1, 3, 5, 0, 0, 7, 
 	0, 0, 9
 };
 
-static const int parse_multiple_response_start = 1;
+static const int mr_extractor_start = 1;
 
-static const int parse_multiple_response_en_main = 1;
+static const int mr_extractor_en_main = 1;
 
 
-#line 11 "./src/spss/readstat_sav_parse_mr_name.rl"
-
+#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
 
 
 readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
@@ -84,18 +82,20 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     // Variables needed for passing Ragel intermediate results
     char mr_type = '\0';
     int mr_counted_value = -1;
-    int mr_subvar_count = -1;
-    char** mr_subvariables = NULL;
-    char* mr_name = NULL;
-    char* mr_label = NULL;
+    int mr_subvar_count = 0;
+    char **mr_subvariables = NULL;
+    char *mr_name = NULL;
+    char *mr_label = NULL;
 
     // Execute Ragel finite state machine (FSM)
     
-#line 95 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 93 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
-	cs = parse_multiple_response_start;
+	cs = mr_extractor_start;
 	}
 
+#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
+    
 #line 100 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
@@ -109,10 +109,10 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 	if ( cs == 0 )
 		goto _out;
 _resume:
-	_keys = _parse_multiple_response_trans_keys + _parse_multiple_response_key_offsets[cs];
-	_trans = _parse_multiple_response_index_offsets[cs];
+	_keys = _mr_extractor_trans_keys + _mr_extractor_key_offsets[cs];
+	_trans = _mr_extractor_index_offsets[cs];
 
-	_klen = _parse_multiple_response_single_lengths[cs];
+	_klen = _mr_extractor_single_lengths[cs];
 	if ( _klen > 0 ) {
 		const char *_lower = _keys;
 		const char *_mid;
@@ -135,7 +135,7 @@ _resume:
 		_trans += _klen;
 	}
 
-	_klen = _parse_multiple_response_range_lengths[cs];
+	_klen = _mr_extractor_range_lengths[cs];
 	if ( _klen > 0 ) {
 		const char *_lower = _keys;
 		const char *_mid;
@@ -158,80 +158,80 @@ _resume:
 	}
 
 _match:
-	_trans = _parse_multiple_response_indicies[_trans];
-	cs = _parse_multiple_response_trans_targs[_trans];
+	_trans = _mr_extractor_indicies[_trans];
+	cs = _mr_extractor_trans_targs[_trans];
 
-	if ( _parse_multiple_response_trans_actions[_trans] == 0 )
+	if ( _mr_extractor_trans_actions[_trans] == 0 )
 		goto _again;
 
-	_acts = _parse_multiple_response_actions + _parse_multiple_response_trans_actions[_trans];
+	_acts = _mr_extractor_actions + _mr_extractor_trans_actions[_trans];
 	_nacts = (unsigned int) *_acts++;
 	while ( _nacts-- > 0 )
 	{
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 33 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 10 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-            mr_name = readstat_malloc(p - start + 1);
-            memcpy(mr_name, start, p - start);
-            mr_name[p - start] = '\0';
-        }
+        mr_name = (char *)malloc(p - start + 1);
+        memcpy(mr_name, start, p - start);
+        mr_name[p - start] = '\0';
+    }
 	break;
 	case 1:
-#line 39 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 16 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-            mr_type = *p;
-            start = p + 1;
-        }
+        mr_type = *p;
+        start = p + 1;
+    }
 	break;
 	case 2:
-#line 44 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 21 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-            int n_cv_digs = p - start;
-            char *n_dig_str = readstat_malloc(n_cv_digs + 1);
-            memcpy(n_dig_str, start, n_cv_digs);
-            n_dig_str[n_cv_digs] = '\0';
-            int n_digs = strtol(n_dig_str, NULL, 10);
-            if (n_digs != 0) {
-                char *cv = readstat_malloc(n_digs + 1);
-                memcpy(cv, p + 1, n_digs);
-                cv[n_digs] = '\0';
-                mr_counted_value = strtol(cv, NULL, 10);
-                p = p + 1 + n_digs;
-                start = p + 1;
-            }
-            else {
-                mr_counted_value = -1;
-            }
+        int n_cv_digs = p - start;
+        char *n_dig_str = (char *)malloc(n_cv_digs + 1);
+        memcpy(n_dig_str, start, n_cv_digs);
+        n_dig_str[n_cv_digs] = '\0';
+        int n_digs = strtol(n_dig_str, NULL, 10);
+        if (n_digs != 0) {
+            char *cv = (char *)malloc(n_digs + 1);
+            memcpy(cv, p + 1, n_digs);
+            cv[n_digs] = '\0';
+            mr_counted_value = strtol(cv, NULL, 10);
+            p = p + 1 + n_digs;
+            start = p + 1;
         }
+        else {
+            mr_counted_value = -1;
+        }
+    }
 	break;
 	case 3:
-#line 63 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 40 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-            char *lbl_len_str = readstat_malloc(p - start + 1);
-            memcpy(lbl_len_str, start, p - start);
-            lbl_len_str[p - start] = '\0';
-            int len = strtol(lbl_len_str, NULL, 10);
-            mr_label = readstat_malloc(len + 1);
-            memcpy(mr_label, p + 1, len);
-            mr_label[len] = '\0';
-            p = p + 1 + len;
-            start = p + 1;
-        }
+        char *lbl_len_str = (char *)malloc(p - start + 1);
+        memcpy(lbl_len_str, start, p - start);
+        lbl_len_str[p - start] = '\0';
+        int len = strtol(lbl_len_str, NULL, 10);
+        mr_label = (char *)malloc(len + 1);
+        memcpy(mr_label, p + 1, len);
+        mr_label[len] = '\0';
+        p = p + 1 + len;
+        start = p + 1;
+    }
 	break;
 	case 4:
-#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 52 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-            int len = p - start;
-            char *subvar = readstat_malloc(len + 1);
-            memcpy(subvar, start, len);
-            subvar[len] = '\0';
-            start = p + 1;
+        int len = p - start;
+        char *subvar = (char *)malloc(len + 1);
+        memcpy(subvar, start, len);
+        subvar[len] = '\0';
+        start = p + 1;
 
-            mr_subvariables = readstat_realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
-            mr_subvariables[mr_subvar_count++] = subvar;
-        }
+        mr_subvariables = realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
+        mr_subvariables[mr_subvar_count++] = subvar;
+    }
 	break;
 #line 237 "./src/spss/readstat_sav_parse_mr_name.c"
 		}
@@ -246,13 +246,15 @@ _again:
 	_out: {}
 	}
 
-#line 99 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
 
-
+    // Check if FSM finished successfully
     if (cs < 9 || p != pe) {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;
     }
+
+    (void)mr_extractor_en_main;
 
     // Assign parsed values to output parameter
     result->name = mr_name;
@@ -276,9 +278,6 @@ cleanup:
         if (mr_name != NULL) free(mr_name);
         if (mr_label != NULL) free(mr_label);
     }
-
-    (void)parse_multiple_response_en_main;
-
     return retval;
 }
 

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -283,9 +283,183 @@ cleanup:
 
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
-    readstat_error_t retval = READSTAT_OK;
     *result = (mr_set_t){0};
+    return extract_mr_data(line, result);
+}
 
-    retval = extract_mr_data(line, result);
+
+#line 292 "./src/spss/readstat_sav_parse_mr_name.c"
+static const char _mr_parser_actions[] = {
+	0, 1, 0
+};
+
+static const char _mr_parser_key_offsets[] = {
+	0, 0, 1, 2, 4
+};
+
+static const char _mr_parser_trans_keys[] = {
+	36, 10, 0, 10, 10, 0
+};
+
+static const char _mr_parser_single_lengths[] = {
+	0, 1, 1, 2, 1
+};
+
+static const char _mr_parser_range_lengths[] = {
+	0, 0, 0, 0, 0
+};
+
+static const char _mr_parser_index_offsets[] = {
+	0, 0, 2, 4, 7
+};
+
+static const char _mr_parser_indicies[] = {
+	0, 1, 2, 0, 3, 2, 0, 2, 
+	0, 0
+};
+
+static const char _mr_parser_trans_targs[] = {
+	2, 0, 3, 4
+};
+
+static const char _mr_parser_trans_actions[] = {
+	0, 0, 1, 0
+};
+
+static const int mr_parser_start = 1;
+
+static const int mr_parser_en_main = 1;
+
+
+#line 157 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+
+readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n_mr_lines) {
+    readstat_error_t retval = READSTAT_OK;
+    int cs = 0;
+    char *p = (char *)line;
+    char *start = p;
+    char *pe = p + strlen(p) + 1;
+    *mr_sets = NULL;
+    *n_mr_lines = 0;
+
+    
+#line 348 "./src/spss/readstat_sav_parse_mr_name.c"
+	{
+	cs = mr_parser_start;
+	}
+
+#line 169 "./src/spss/readstat_sav_parse_mr_name.rl"
+    
+#line 355 "./src/spss/readstat_sav_parse_mr_name.c"
+	{
+	int _klen;
+	unsigned int _trans;
+	const char *_acts;
+	unsigned int _nacts;
+	const char *_keys;
+
+	if ( p == pe )
+		goto _test_eof;
+	if ( cs == 0 )
+		goto _out;
+_resume:
+	_keys = _mr_parser_trans_keys + _mr_parser_key_offsets[cs];
+	_trans = _mr_parser_index_offsets[cs];
+
+	_klen = _mr_parser_single_lengths[cs];
+	if ( _klen > 0 ) {
+		const char *_lower = _keys;
+		const char *_mid;
+		const char *_upper = _keys + _klen - 1;
+		while (1) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + ((_upper-_lower) >> 1);
+			if ( (*p) < *_mid )
+				_upper = _mid - 1;
+			else if ( (*p) > *_mid )
+				_lower = _mid + 1;
+			else {
+				_trans += (unsigned int)(_mid - _keys);
+				goto _match;
+			}
+		}
+		_keys += _klen;
+		_trans += _klen;
+	}
+
+	_klen = _mr_parser_range_lengths[cs];
+	if ( _klen > 0 ) {
+		const char *_lower = _keys;
+		const char *_mid;
+		const char *_upper = _keys + (_klen<<1) - 2;
+		while (1) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
+			if ( (*p) < _mid[0] )
+				_upper = _mid - 2;
+			else if ( (*p) > _mid[1] )
+				_lower = _mid + 2;
+			else {
+				_trans += (unsigned int)((_mid - _keys)>>1);
+				goto _match;
+			}
+		}
+		_trans += _klen;
+	}
+
+_match:
+	_trans = _mr_parser_indicies[_trans];
+	cs = _mr_parser_trans_targs[_trans];
+
+	if ( _mr_parser_trans_actions[_trans] == 0 )
+		goto _again;
+
+	_acts = _mr_parser_actions + _mr_parser_trans_actions[_trans];
+	_nacts = (unsigned int) *_acts++;
+	while ( _nacts-- > 0 )
+	{
+		switch ( *_acts++ )
+		{
+	case 0:
+#line 140 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        char *mln = (char *)malloc(p - start);
+        memcpy(mln, start + 1, p - start);
+        mln[p - start - 1] = '\0';
+        *mr_sets = realloc(*mr_sets, ((*n_mr_lines) + 1) * sizeof(mr_set_t));
+        retval = parse_mr_line(mln, &(*mr_sets)[*n_mr_lines]);
+        if (retval != READSTAT_OK) goto cleanup;
+        (*n_mr_lines)++;
+        start = p + 1;
+    }
+	break;
+#line 442 "./src/spss/readstat_sav_parse_mr_name.c"
+		}
+	}
+
+_again:
+	if ( cs == 0 )
+		goto _out;
+	if ( ++p != pe )
+		goto _resume;
+	_test_eof: {}
+	_out: {}
+	}
+
+#line 170 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+    if (cs < 4 || p != pe) {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+
+    (void)mr_parser_en_main;
+
+cleanup:
     return retval;
 }

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -3,14 +3,15 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "readstat.h"
+#include "../readstat.h"
+#include "readstat_sav_parse_mr_name.h"
 
 
-#line 72 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 73 "./src/spss/readstat_sav_parse_mr_name.rl"
 
 
 
-#line 14 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 15 "./src/spss/readstat_sav_parse_mr_name.c"
 static const char _mr_name_and_label_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	3, 1, 4
@@ -72,7 +73,7 @@ static const int mr_name_and_label_error = 0;
 static const int mr_name_and_label_en_name_extractor = 1;
 
 
-#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 76 "./src/spss/readstat_sav_parse_mr_name.rl"
 
 readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     readstat_error_t retval = READSTAT_OK;
@@ -85,22 +86,22 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 
     // Variables needed for passing Ragel intermediate results
     char mr_type;
-    int mr_counted_value;
-    int mr_subvar_count;
+    int mr_counted_value = -1;
+    int mr_subvar_count = -1;
     char **mr_subvariables = NULL;
     char *mr_name = NULL;
     char *mr_label = NULL;
 
     // Execute Ragel finite state machine (FSM)
     
-#line 97 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 98 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_name_and_label_start;
 	}
 
-#line 95 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 104 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 105 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -175,30 +176,30 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 9 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 10 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        mr_name = (char *)malloc(p - start + 1);
+        mr_name = (char *)readstat_malloc(p - start + 1);
         memcpy(mr_name, start, p - start);
         mr_name[p - start] = '\0';
     }
 	break;
 	case 1:
-#line 15 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 16 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         mr_type = *p;
         start = p + 1;
     }
 	break;
 	case 2:
-#line 20 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 21 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int n_cv_digs = p - start;
-        char *n_dig_str = (char *)malloc(n_cv_digs + 1);
+        char *n_dig_str = (char *)readstat_malloc(n_cv_digs + 1);
         memcpy(n_dig_str, start, n_cv_digs);
         n_dig_str[n_cv_digs] = '\0';
         int n_digs = strtol(n_dig_str, NULL, 10);
         if (n_digs != 0) {
-            char *cv = (char *)malloc(n_digs + 1);
+            char *cv = (char *)readstat_malloc(n_digs + 1);
             memcpy(cv, p + 1, n_digs);
             cv[n_digs] = '\0';
             mr_counted_value = strtol(cv, NULL, 10);
@@ -211,13 +212,13 @@ _match:
     }
 	break;
 	case 3:
-#line 39 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 40 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        char *lbl_len_str = (char *)malloc(p - start + 1);
+        char *lbl_len_str = (char *)readstat_malloc(p - start + 1);
         memcpy(lbl_len_str, start, p - start);
         lbl_len_str[p - start] = '\0';
         int len = strtol(lbl_len_str, NULL, 10);
-        mr_label = (char *)malloc(len + 1);
+        mr_label = (char *)readstat_malloc(len + 1);
         memcpy(mr_label, p + 1, len);
         mr_label[len] = '\0';
         p = p + 1 + len;
@@ -225,19 +226,19 @@ _match:
     }
 	break;
 	case 4:
-#line 51 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 52 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int len = p - start;
-        char *subvar = (char *)malloc(len + 1);
+        char *subvar = (char *)readstat_malloc(len + 1);
         memcpy(subvar, start, len);
         subvar[len] = '\0';
         start = p + 1;
 
-        mr_subvariables = realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
+        mr_subvariables = readstat_realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 	break;
-#line 241 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 242 "./src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -250,7 +251,7 @@ _again:
 	_out: {}
 	}
 
-#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
 
     // Check if FSM finished successfully
     if (cs < 9 || p != pe) {
@@ -259,8 +260,8 @@ _again:
     }
 
     // Assign parsed values to output parameter
-    result->name = strdup(mr_name);
-    result->label = strdup(mr_label);
+    result->name = mr_name;
+    result->label = mr_label;
     result->type = mr_type;
     result->counted_value = mr_counted_value;
     result->subvariables = mr_subvariables;

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -82,7 +82,7 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     char *pe = p + strlen(p) + 1;
 
     // Variables needed for passing Ragel intermediate results
-    char mr_type;
+    char mr_type = '\0';
     int mr_counted_value = -1;
     int mr_subvar_count = -1;
     char** mr_subvariables = NULL;

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -1,5 +1,5 @@
 
-#line 1 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 1 "src/spss/readstat_sav_parse_mr_name.rl"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,7 +7,7 @@
 #include "../readstat_malloc.h"
 
 
-#line 11 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 11 "src/spss/readstat_sav_parse_mr_name.c"
 static const char _mr_extractor_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	3, 1, 4
@@ -67,7 +67,7 @@ static const int mr_extractor_start = 1;
 static const int mr_extractor_en_main = 1;
 
 
-#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 75 "src/spss/readstat_sav_parse_mr_name.rl"
 
 
 readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
@@ -89,14 +89,14 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 
     // Execute Ragel finite state machine (FSM)
     
-#line 93 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 93 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_extractor_start;
 	}
 
-#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 96 "src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 100 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 100 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -171,7 +171,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 10 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 10 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         mr_name = (char *)malloc(p - start + 1);
         memcpy(mr_name, start, p - start);
@@ -179,14 +179,14 @@ _match:
     }
 	break;
 	case 1:
-#line 16 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 16 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         mr_type = *p;
         start = p + 1;
     }
 	break;
 	case 2:
-#line 21 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 21 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int n_cv_digs = p - start;
         char *n_dig_str = (char *)malloc(n_cv_digs + 1);
@@ -207,7 +207,7 @@ _match:
     }
 	break;
 	case 3:
-#line 40 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 40 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         char *lbl_len_str = (char *)malloc(p - start + 1);
         memcpy(lbl_len_str, start, p - start);
@@ -221,7 +221,7 @@ _match:
     }
 	break;
 	case 4:
-#line 52 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 52 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int len = p - start;
         char *subvar = (char *)malloc(len + 1);
@@ -233,7 +233,7 @@ _match:
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 	break;
-#line 237 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 237 "src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -246,7 +246,7 @@ _again:
 	_out: {}
 	}
 
-#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 97 "src/spss/readstat_sav_parse_mr_name.rl"
 
     // Check if FSM finished successfully
     if (cs < 9 || p != pe) {
@@ -288,7 +288,7 @@ readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
 }
 
 
-#line 292 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 292 "src/spss/readstat_sav_parse_mr_name.c"
 static const char _mr_parser_actions[] = {
 	0, 1, 0
 };
@@ -331,7 +331,7 @@ static const int mr_parser_start = 1;
 static const int mr_parser_en_main = 1;
 
 
-#line 157 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 160 "src/spss/readstat_sav_parse_mr_name.rl"
 
 
 readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n_mr_lines) {
@@ -344,14 +344,14 @@ readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n
     *n_mr_lines = 0;
 
     
-#line 348 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 348 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_parser_start;
 	}
 
-#line 169 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 172 "src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 355 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 355 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -426,19 +426,22 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 140 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 140 "src/spss/readstat_sav_parse_mr_name.rl"
 	{
         char *mln = (char *)malloc(p - start);
         memcpy(mln, start + 1, p - start);
         mln[p - start - 1] = '\0';
         *mr_sets = realloc(*mr_sets, ((*n_mr_lines) + 1) * sizeof(mr_set_t));
         retval = parse_mr_line(mln, &(*mr_sets)[*n_mr_lines]);
-        if (retval != READSTAT_OK) goto cleanup;
+        if (retval != READSTAT_OK) {
+            if (mln == NULL) free(mln);
+            goto cleanup;
+        }
         (*n_mr_lines)++;
         start = p + 1;
     }
 	break;
-#line 442 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 445 "src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -451,7 +454,7 @@ _again:
 	_out: {}
 	}
 
-#line 170 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 173 "src/spss/readstat_sav_parse_mr_name.rl"
 
     if (cs < 4 || p != pe) {
         retval = READSTAT_ERROR_BAD_MR_STRING;

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -8,22 +8,18 @@
 #include "readstat_sav_parse_mr_name.h"
 
 
-#line 74 "./src/spss/readstat_sav_parse_mr_name.rl"
-
-
-
-#line 16 "./src/spss/readstat_sav_parse_mr_name.c"
-static const char _mr_name_and_label_actions[] = {
+#line 12 "./src/spss/readstat_sav_parse_mr_name.c"
+static const char _parse_multiple_response_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	3, 1, 4
 };
 
-static const char _mr_name_and_label_key_offsets[] = {
+static const char _parse_multiple_response_key_offsets[] = {
 	0, 0, 7, 15, 17, 20, 22, 25, 
 	33, 44
 };
 
-static const char _mr_name_and_label_trans_keys[] = {
+static const char _parse_multiple_response_trans_keys[] = {
 	95, 48, 57, 65, 90, 97, 122, 61, 
 	95, 48, 57, 65, 90, 97, 122, 67, 
 	68, 32, 48, 57, 48, 57, 32, 48, 
@@ -33,22 +29,22 @@ static const char _mr_name_and_label_trans_keys[] = {
 	90, 97, 122, 0
 };
 
-static const char _mr_name_and_label_single_lengths[] = {
+static const char _parse_multiple_response_single_lengths[] = {
 	0, 1, 2, 0, 1, 0, 1, 2, 
 	3, 1
 };
 
-static const char _mr_name_and_label_range_lengths[] = {
+static const char _parse_multiple_response_range_lengths[] = {
 	0, 3, 3, 1, 1, 1, 1, 3, 
 	4, 3
 };
 
-static const char _mr_name_and_label_index_offsets[] = {
+static const char _parse_multiple_response_index_offsets[] = {
 	0, 0, 5, 11, 13, 16, 18, 21, 
 	27, 35
 };
 
-static const char _mr_name_and_label_indicies[] = {
+static const char _parse_multiple_response_indicies[] = {
 	0, 0, 0, 0, 1, 2, 0, 0, 
 	0, 0, 1, 3, 1, 4, 5, 1, 
 	6, 1, 7, 6, 1, 8, 9, 9, 
@@ -57,24 +53,24 @@ static const char _mr_name_and_label_indicies[] = {
 	0
 };
 
-static const char _mr_name_and_label_trans_targs[] = {
+static const char _parse_multiple_response_trans_targs[] = {
 	2, 0, 3, 4, 5, 4, 6, 7, 
 	7, 8, 9
 };
 
-static const char _mr_name_and_label_trans_actions[] = {
+static const char _parse_multiple_response_trans_actions[] = {
 	0, 0, 1, 3, 5, 0, 0, 7, 
 	0, 0, 9
 };
 
-static const int mr_name_and_label_start = 1;
-static const int mr_name_and_label_first_final = 9;
-static const int mr_name_and_label_error = 0;
+static const int parse_multiple_response_start = 1;
 
-static const int mr_name_and_label_en_name_extractor = 1;
+static const int parse_multiple_response_en_main = 1;
 
 
-#line 77 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 11 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+
 
 readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     readstat_error_t retval = READSTAT_OK;
@@ -95,14 +91,12 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 
     // Execute Ragel finite state machine (FSM)
     
-#line 99 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 95 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
-	cs = mr_name_and_label_start;
+	cs = parse_multiple_response_start;
 	}
 
-#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
-    
-#line 106 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 100 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -115,10 +109,10 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 	if ( cs == 0 )
 		goto _out;
 _resume:
-	_keys = _mr_name_and_label_trans_keys + _mr_name_and_label_key_offsets[cs];
-	_trans = _mr_name_and_label_index_offsets[cs];
+	_keys = _parse_multiple_response_trans_keys + _parse_multiple_response_key_offsets[cs];
+	_trans = _parse_multiple_response_index_offsets[cs];
 
-	_klen = _mr_name_and_label_single_lengths[cs];
+	_klen = _parse_multiple_response_single_lengths[cs];
 	if ( _klen > 0 ) {
 		const char *_lower = _keys;
 		const char *_mid;
@@ -141,7 +135,7 @@ _resume:
 		_trans += _klen;
 	}
 
-	_klen = _mr_name_and_label_range_lengths[cs];
+	_klen = _parse_multiple_response_range_lengths[cs];
 	if ( _klen > 0 ) {
 		const char *_lower = _keys;
 		const char *_mid;
@@ -164,82 +158,82 @@ _resume:
 	}
 
 _match:
-	_trans = _mr_name_and_label_indicies[_trans];
-	cs = _mr_name_and_label_trans_targs[_trans];
+	_trans = _parse_multiple_response_indicies[_trans];
+	cs = _parse_multiple_response_trans_targs[_trans];
 
-	if ( _mr_name_and_label_trans_actions[_trans] == 0 )
+	if ( _parse_multiple_response_trans_actions[_trans] == 0 )
 		goto _again;
 
-	_acts = _mr_name_and_label_actions + _mr_name_and_label_trans_actions[_trans];
+	_acts = _parse_multiple_response_actions + _parse_multiple_response_trans_actions[_trans];
 	_nacts = (unsigned int) *_acts++;
 	while ( _nacts-- > 0 )
 	{
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 11 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 33 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        mr_name = readstat_malloc(p - start + 1);
-        memcpy(mr_name, start, p - start);
-        mr_name[p - start] = '\0';
-    }
+            mr_name = readstat_malloc(p - start + 1);
+            memcpy(mr_name, start, p - start);
+            mr_name[p - start] = '\0';
+        }
 	break;
 	case 1:
-#line 17 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 39 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        mr_type = *p;
-        start = p + 1;
-    }
-	break;
-	case 2:
-#line 22 "./src/spss/readstat_sav_parse_mr_name.rl"
-	{
-        int n_cv_digs = p - start;
-        char *n_dig_str = readstat_malloc(n_cv_digs + 1);
-        memcpy(n_dig_str, start, n_cv_digs);
-        n_dig_str[n_cv_digs] = '\0';
-        int n_digs = strtol(n_dig_str, NULL, 10);
-        if (n_digs != 0) {
-            char *cv = readstat_malloc(n_digs + 1);
-            memcpy(cv, p + 1, n_digs);
-            cv[n_digs] = '\0';
-            mr_counted_value = strtol(cv, NULL, 10);
-            p = p + 1 + n_digs;
+            mr_type = *p;
             start = p + 1;
         }
-        else {
-            mr_counted_value = -1;
+	break;
+	case 2:
+#line 44 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+            int n_cv_digs = p - start;
+            char *n_dig_str = readstat_malloc(n_cv_digs + 1);
+            memcpy(n_dig_str, start, n_cv_digs);
+            n_dig_str[n_cv_digs] = '\0';
+            int n_digs = strtol(n_dig_str, NULL, 10);
+            if (n_digs != 0) {
+                char *cv = readstat_malloc(n_digs + 1);
+                memcpy(cv, p + 1, n_digs);
+                cv[n_digs] = '\0';
+                mr_counted_value = strtol(cv, NULL, 10);
+                p = p + 1 + n_digs;
+                start = p + 1;
+            }
+            else {
+                mr_counted_value = -1;
+            }
         }
-    }
 	break;
 	case 3:
-#line 41 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 63 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        char *lbl_len_str = readstat_malloc(p - start + 1);
-        memcpy(lbl_len_str, start, p - start);
-        lbl_len_str[p - start] = '\0';
-        int len = strtol(lbl_len_str, NULL, 10);
-        mr_label = readstat_malloc(len + 1);
-        memcpy(mr_label, p + 1, len);
-        mr_label[len] = '\0';
-        p = p + 1 + len;
-        start = p + 1;
-    }
+            char *lbl_len_str = readstat_malloc(p - start + 1);
+            memcpy(lbl_len_str, start, p - start);
+            lbl_len_str[p - start] = '\0';
+            int len = strtol(lbl_len_str, NULL, 10);
+            mr_label = readstat_malloc(len + 1);
+            memcpy(mr_label, p + 1, len);
+            mr_label[len] = '\0';
+            p = p + 1 + len;
+            start = p + 1;
+        }
 	break;
 	case 4:
-#line 53 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        int len = p - start;
-        char *subvar = readstat_malloc(len + 1);
-        memcpy(subvar, start, len);
-        subvar[len] = '\0';
-        start = p + 1;
+            int len = p - start;
+            char *subvar = readstat_malloc(len + 1);
+            memcpy(subvar, start, len);
+            subvar[len] = '\0';
+            start = p + 1;
 
-        mr_subvariables = readstat_realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
-        mr_subvariables[mr_subvar_count++] = subvar;
-    }
+            mr_subvariables = readstat_realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
+            mr_subvariables[mr_subvar_count++] = subvar;
+        }
 	break;
-#line 243 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 237 "./src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -252,9 +246,9 @@ _again:
 	_out: {}
 	}
 
-#line 98 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 99 "./src/spss/readstat_sav_parse_mr_name.rl"
 
-    // Check if FSM finished successfully
+
     if (cs < 9 || p != pe) {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;
@@ -282,11 +276,17 @@ cleanup:
         if (mr_name != NULL) free(mr_name);
         if (mr_label != NULL) free(mr_label);
     }
+
+    (void)parse_multiple_response_en_main;
+
     return retval;
 }
 
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
     *result = (mr_set_t){0};
-    return extract_mr_data(line, result);
+
+    retval = extract_mr_data(line, result);
+    return retval;
 }

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -4,14 +4,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "../readstat.h"
+#include "../readstat_malloc.h"
 #include "readstat_sav_parse_mr_name.h"
 
 
-#line 73 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 74 "./src/spss/readstat_sav_parse_mr_name.rl"
 
 
 
-#line 15 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 16 "./src/spss/readstat_sav_parse_mr_name.c"
 static const char _mr_name_and_label_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	3, 1, 4
@@ -73,7 +74,7 @@ static const int mr_name_and_label_error = 0;
 static const int mr_name_and_label_en_name_extractor = 1;
 
 
-#line 76 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 77 "./src/spss/readstat_sav_parse_mr_name.rl"
 
 readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     readstat_error_t retval = READSTAT_OK;
@@ -88,20 +89,20 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     char mr_type;
     int mr_counted_value = -1;
     int mr_subvar_count = -1;
-    char **mr_subvariables = NULL;
-    char *mr_name = NULL;
-    char *mr_label = NULL;
+    char** mr_subvariables = NULL;
+    char* mr_name = NULL;
+    char* mr_label = NULL;
 
     // Execute Ragel finite state machine (FSM)
     
-#line 98 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 99 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_name_and_label_start;
 	}
 
-#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 105 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 106 "./src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -176,7 +177,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 10 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 11 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         mr_name = readstat_malloc(p - start + 1);
         memcpy(mr_name, start, p - start);
@@ -184,14 +185,14 @@ _match:
     }
 	break;
 	case 1:
-#line 16 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 17 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         mr_type = *p;
         start = p + 1;
     }
 	break;
 	case 2:
-#line 21 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 22 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int n_cv_digs = p - start;
         char *n_dig_str = readstat_malloc(n_cv_digs + 1);
@@ -212,7 +213,7 @@ _match:
     }
 	break;
 	case 3:
-#line 40 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 41 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         char *lbl_len_str = readstat_malloc(p - start + 1);
         memcpy(lbl_len_str, start, p - start);
@@ -226,7 +227,7 @@ _match:
     }
 	break;
 	case 4:
-#line 52 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 53 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int len = p - start;
         char *subvar = readstat_malloc(len + 1);
@@ -238,7 +239,7 @@ _match:
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 	break;
-#line 242 "./src/spss/readstat_sav_parse_mr_name.c"
+#line 243 "./src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -251,7 +252,7 @@ _again:
 	_out: {}
 	}
 
-#line 97 "./src/spss/readstat_sav_parse_mr_name.rl"
+#line 98 "./src/spss/readstat_sav_parse_mr_name.rl"
 
     // Check if FSM finished successfully
     if (cs < 9 || p != pe) {
@@ -286,8 +287,6 @@ cleanup:
 
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
-    readstat_error_t retval = READSTAT_OK;
     *result = (mr_set_t){0};
-
     return extract_mr_data(line, result);
 }

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -178,7 +178,7 @@ _match:
 	case 0:
 #line 10 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        mr_name = (char *)readstat_malloc(p - start + 1);
+        mr_name = readstat_malloc(p - start + 1);
         memcpy(mr_name, start, p - start);
         mr_name[p - start] = '\0';
     }
@@ -194,12 +194,12 @@ _match:
 #line 21 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int n_cv_digs = p - start;
-        char *n_dig_str = (char *)readstat_malloc(n_cv_digs + 1);
+        char *n_dig_str = readstat_malloc(n_cv_digs + 1);
         memcpy(n_dig_str, start, n_cv_digs);
         n_dig_str[n_cv_digs] = '\0';
         int n_digs = strtol(n_dig_str, NULL, 10);
         if (n_digs != 0) {
-            char *cv = (char *)readstat_malloc(n_digs + 1);
+            char *cv = readstat_malloc(n_digs + 1);
             memcpy(cv, p + 1, n_digs);
             cv[n_digs] = '\0';
             mr_counted_value = strtol(cv, NULL, 10);
@@ -214,11 +214,11 @@ _match:
 	case 3:
 #line 40 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
-        char *lbl_len_str = (char *)readstat_malloc(p - start + 1);
+        char *lbl_len_str = readstat_malloc(p - start + 1);
         memcpy(lbl_len_str, start, p - start);
         lbl_len_str[p - start] = '\0';
         int len = strtol(lbl_len_str, NULL, 10);
-        mr_label = (char *)readstat_malloc(len + 1);
+        mr_label = readstat_malloc(len + 1);
         memcpy(mr_label, p + 1, len);
         mr_label[len] = '\0';
         p = p + 1 + len;
@@ -229,7 +229,7 @@ _match:
 #line 52 "./src/spss/readstat_sav_parse_mr_name.rl"
 	{
         int len = p - start;
-        char *subvar = (char *)readstat_malloc(len + 1);
+        char *subvar = readstat_malloc(len + 1);
         memcpy(subvar, start, len);
         subvar[len] = '\0';
         start = p + 1;

--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -1,0 +1,292 @@
+
+#line 1 "./src/spss/readstat_sav_parse_mr_name.rl"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "readstat.h"
+
+
+#line 72 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+
+
+#line 14 "./src/spss/readstat_sav_parse_mr_name.c"
+static const char _mr_name_and_label_actions[] = {
+	0, 1, 0, 1, 1, 1, 2, 1, 
+	3, 1, 4
+};
+
+static const char _mr_name_and_label_key_offsets[] = {
+	0, 0, 7, 15, 17, 20, 22, 25, 
+	33, 44
+};
+
+static const char _mr_name_and_label_trans_keys[] = {
+	95, 48, 57, 65, 90, 97, 122, 61, 
+	95, 48, 57, 65, 90, 97, 122, 67, 
+	68, 32, 48, 57, 48, 57, 32, 48, 
+	57, 32, 95, 48, 57, 65, 90, 97, 
+	122, 0, 32, 95, 9, 13, 48, 57, 
+	65, 90, 97, 122, 95, 48, 57, 65, 
+	90, 97, 122, 0
+};
+
+static const char _mr_name_and_label_single_lengths[] = {
+	0, 1, 2, 0, 1, 0, 1, 2, 
+	3, 1
+};
+
+static const char _mr_name_and_label_range_lengths[] = {
+	0, 3, 3, 1, 1, 1, 1, 3, 
+	4, 3
+};
+
+static const char _mr_name_and_label_index_offsets[] = {
+	0, 0, 5, 11, 13, 16, 18, 21, 
+	27, 35
+};
+
+static const char _mr_name_and_label_indicies[] = {
+	0, 0, 0, 0, 1, 2, 0, 0, 
+	0, 0, 1, 3, 1, 4, 5, 1, 
+	6, 1, 7, 6, 1, 8, 9, 9, 
+	9, 9, 1, 10, 10, 9, 10, 9, 
+	9, 9, 1, 9, 9, 9, 9, 1, 
+	0
+};
+
+static const char _mr_name_and_label_trans_targs[] = {
+	2, 0, 3, 4, 5, 4, 6, 7, 
+	7, 8, 9
+};
+
+static const char _mr_name_and_label_trans_actions[] = {
+	0, 0, 1, 3, 5, 0, 0, 7, 
+	0, 0, 9
+};
+
+static const int mr_name_and_label_start = 1;
+static const int mr_name_and_label_first_final = 9;
+static const int mr_name_and_label_error = 0;
+
+static const int mr_name_and_label_en_name_extractor = 1;
+
+
+#line 75 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+
+    // Variables needed for Ragel operation
+    int cs = 0;
+    char *p = (char *)line;
+    char *start = p;
+    char *pe = p + strlen(p) + 1;
+
+    // Variables needed for passing Ragel intermediate results
+    char mr_type;
+    int mr_counted_value;
+    int mr_subvar_count;
+    char **mr_subvariables = NULL;
+    char *mr_name = NULL;
+    char *mr_label = NULL;
+
+    // Execute Ragel finite state machine (FSM)
+    
+#line 97 "./src/spss/readstat_sav_parse_mr_name.c"
+	{
+	cs = mr_name_and_label_start;
+	}
+
+#line 95 "./src/spss/readstat_sav_parse_mr_name.rl"
+    
+#line 104 "./src/spss/readstat_sav_parse_mr_name.c"
+	{
+	int _klen;
+	unsigned int _trans;
+	const char *_acts;
+	unsigned int _nacts;
+	const char *_keys;
+
+	if ( p == pe )
+		goto _test_eof;
+	if ( cs == 0 )
+		goto _out;
+_resume:
+	_keys = _mr_name_and_label_trans_keys + _mr_name_and_label_key_offsets[cs];
+	_trans = _mr_name_and_label_index_offsets[cs];
+
+	_klen = _mr_name_and_label_single_lengths[cs];
+	if ( _klen > 0 ) {
+		const char *_lower = _keys;
+		const char *_mid;
+		const char *_upper = _keys + _klen - 1;
+		while (1) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + ((_upper-_lower) >> 1);
+			if ( (*p) < *_mid )
+				_upper = _mid - 1;
+			else if ( (*p) > *_mid )
+				_lower = _mid + 1;
+			else {
+				_trans += (unsigned int)(_mid - _keys);
+				goto _match;
+			}
+		}
+		_keys += _klen;
+		_trans += _klen;
+	}
+
+	_klen = _mr_name_and_label_range_lengths[cs];
+	if ( _klen > 0 ) {
+		const char *_lower = _keys;
+		const char *_mid;
+		const char *_upper = _keys + (_klen<<1) - 2;
+		while (1) {
+			if ( _upper < _lower )
+				break;
+
+			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
+			if ( (*p) < _mid[0] )
+				_upper = _mid - 2;
+			else if ( (*p) > _mid[1] )
+				_lower = _mid + 2;
+			else {
+				_trans += (unsigned int)((_mid - _keys)>>1);
+				goto _match;
+			}
+		}
+		_trans += _klen;
+	}
+
+_match:
+	_trans = _mr_name_and_label_indicies[_trans];
+	cs = _mr_name_and_label_trans_targs[_trans];
+
+	if ( _mr_name_and_label_trans_actions[_trans] == 0 )
+		goto _again;
+
+	_acts = _mr_name_and_label_actions + _mr_name_and_label_trans_actions[_trans];
+	_nacts = (unsigned int) *_acts++;
+	while ( _nacts-- > 0 )
+	{
+		switch ( *_acts++ )
+		{
+	case 0:
+#line 9 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        mr_name = (char *)malloc(p - start + 1);
+        memcpy(mr_name, start, p - start);
+        mr_name[p - start] = '\0';
+    }
+	break;
+	case 1:
+#line 15 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        mr_type = *p;
+        start = p + 1;
+    }
+	break;
+	case 2:
+#line 20 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        int n_cv_digs = p - start;
+        char *n_dig_str = (char *)malloc(n_cv_digs + 1);
+        memcpy(n_dig_str, start, n_cv_digs);
+        n_dig_str[n_cv_digs] = '\0';
+        int n_digs = strtol(n_dig_str, NULL, 10);
+        if (n_digs != 0) {
+            char *cv = (char *)malloc(n_digs + 1);
+            memcpy(cv, p + 1, n_digs);
+            cv[n_digs] = '\0';
+            mr_counted_value = strtol(cv, NULL, 10);
+            p = p + 1 + n_digs;
+            start = p + 1;
+        }
+        else {
+            mr_counted_value = -1;
+        }
+    }
+	break;
+	case 3:
+#line 39 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        char *lbl_len_str = (char *)malloc(p - start + 1);
+        memcpy(lbl_len_str, start, p - start);
+        lbl_len_str[p - start] = '\0';
+        int len = strtol(lbl_len_str, NULL, 10);
+        mr_label = (char *)malloc(len + 1);
+        memcpy(mr_label, p + 1, len);
+        mr_label[len] = '\0';
+        p = p + 1 + len;
+        start = p + 1;
+    }
+	break;
+	case 4:
+#line 51 "./src/spss/readstat_sav_parse_mr_name.rl"
+	{
+        int len = p - start;
+        char *subvar = (char *)malloc(len + 1);
+        memcpy(subvar, start, len);
+        subvar[len] = '\0';
+        start = p + 1;
+
+        mr_subvariables = realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
+        mr_subvariables[mr_subvar_count++] = subvar;
+    }
+	break;
+#line 241 "./src/spss/readstat_sav_parse_mr_name.c"
+		}
+	}
+
+_again:
+	if ( cs == 0 )
+		goto _out;
+	if ( ++p != pe )
+		goto _resume;
+	_test_eof: {}
+	_out: {}
+	}
+
+#line 96 "./src/spss/readstat_sav_parse_mr_name.rl"
+
+    // Check if FSM finished successfully
+    if (cs < 9 || p != pe) {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+
+    // Assign parsed values to output parameter
+    result->name = strdup(mr_name);
+    result->label = strdup(mr_label);
+    result->type = mr_type;
+    result->counted_value = mr_counted_value;
+    result->subvariables = mr_subvariables;
+    result->num_subvars = mr_subvar_count;
+    if (result->type == 'D') {
+        result->is_dichotomy = 1;
+    }
+
+cleanup:
+    if (retval != READSTAT_OK) {
+        if (mr_subvariables != NULL) {
+            for (int i = 0; i < mr_subvar_count; i++) {
+                if (mr_subvariables[i] != NULL) free(mr_subvariables[i]);
+            }
+            free(mr_subvariables);
+        }
+        if (mr_name != NULL) free(mr_name);
+        if (mr_label != NULL) free(mr_label);
+    }
+    return retval;
+}
+
+
+readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+    *result = (mr_set_t){0};
+
+    return extract_mr_data(line, result);
+}

--- a/src/spss/readstat_sav_parse_mr_name.h
+++ b/src/spss/readstat_sav_parse_mr_name.h
@@ -1,0 +1,8 @@
+#ifndef READSTAT_PARSE_MR_NAME_H
+#define READSTAT_PARSE_MR_NAME_H
+
+#include "../readstat.h"
+
+readstat_error_t parse_mr_line(const char *line, mr_set_t *result);
+
+#endif // READSTAT_PARSE_MR_NAME_H

--- a/src/spss/readstat_sav_parse_mr_name.h
+++ b/src/spss/readstat_sav_parse_mr_name.h
@@ -4,6 +4,6 @@
 #include "../readstat.h"
 #include "../readstat_malloc.h"
 
-readstat_error_t parse_mr_line(const char *line, mr_set_t *result);
+readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n_mr_lines);
 
 #endif // READSTAT_PARSE_MR_NAME_H

--- a/src/spss/readstat_sav_parse_mr_name.h
+++ b/src/spss/readstat_sav_parse_mr_name.h
@@ -2,6 +2,7 @@
 #define READSTAT_PARSE_MR_NAME_H
 
 #include "../readstat.h"
+#include "../readstat_malloc.h"
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result);
 

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -60,13 +60,13 @@
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 
-    name = (alnum | '_')+ '=' > extract_mr_name;
+    nc = (alnum | '_'); # name character
+    name = nc+ '=' > extract_mr_name;
     type = ('C' | 'D'){1} > extract_mr_type;
     counted_value = digit* ' ' > extract_counted_value;
     label = digit+ ' '+ > extract_label;
 
-    nc = (alnum | '_'); # name character
-    end = (space | '\0'); # token terminator
+    end = (space | '\0'); # subvar token terminator
     subvariable = (nc+ end >extract_subvar);
 
     main := name type counted_value label subvariable+;
@@ -130,9 +130,51 @@ cleanup:
 
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
-    readstat_error_t retval = READSTAT_OK;
     *result = (mr_set_t){0};
+    return extract_mr_data(line, result);
+}
 
-    retval = extract_mr_data(line, result);
+%%{
+    machine mr_parser;
+
+    action mr_line {
+        char *mln = (char *)malloc(p - start);
+        memcpy(mln, start + 1, p - start);
+        mln[p - start - 1] = '\0';
+        *mr_sets = realloc(*mr_sets, ((*n_mr_lines) + 1) * sizeof(mr_set_t));
+        retval = parse_mr_line(mln, &(*mr_sets)[*n_mr_lines]);
+        if (retval != READSTAT_OK) goto cleanup;
+        (*n_mr_lines)++;
+        start = p + 1;
+    }
+    line_start = '$';
+    line_end = '\n';
+    line_char = any - (line_end + line_start);
+    mr_line = line_start line_char* line_end > mr_line;
+    main := mr_line+ '\0';
+
+    write data nofinal noerror;
+}%%
+
+readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n_mr_lines) {
+    readstat_error_t retval = READSTAT_OK;
+    int cs = 0;
+    char *p = (char *)line;
+    char *start = p;
+    char *pe = p + strlen(p) + 1;
+    *mr_sets = NULL;
+    *n_mr_lines = 0;
+
+    %% write init;
+    %% write exec;
+
+    if (cs < %%{ write first_final; }%% || p != pe) {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+
+    (void)mr_parser_en_main;
+
+cleanup:
     return retval;
 }

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -21,7 +21,7 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     char *pe = p + strlen(p) + 1;
 
     // Variables needed for passing Ragel intermediate results
-    char mr_type;
+    char mr_type = '\0';
     int mr_counted_value = -1;
     int mr_subvar_count = -1;
     char** mr_subvariables = NULL;

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "../readstat.h"
+#include "../readstat_malloc.h"
 #include "readstat_sav_parse_mr_name.h"
 
 %%{
@@ -87,9 +88,9 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
     char mr_type;
     int mr_counted_value = -1;
     int mr_subvar_count = -1;
-    char **mr_subvariables = NULL;
-    char *mr_name = NULL;
-    char *mr_label = NULL;
+    char** mr_subvariables = NULL;
+    char* mr_name = NULL;
+    char* mr_label = NULL;
 
     // Execute Ragel finite state machine (FSM)
     %% write init;
@@ -128,8 +129,6 @@ cleanup:
 
 
 readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
-    readstat_error_t retval = READSTAT_OK;
     *result = (mr_set_t){0};
-
     return extract_mr_data(line, result);
 }

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -1,0 +1,134 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "readstat.h"
+
+%%{
+    machine mr_name_and_label;
+
+    action extract_mr_name {
+        mr_name = (char *)malloc(p - start + 1);
+        memcpy(mr_name, start, p - start);
+        mr_name[p - start] = '\0';
+    }
+
+    action extract_mr_type {
+        mr_type = *p;
+        start = p + 1;
+    }
+
+    action extract_counted_value {
+        int n_cv_digs = p - start;
+        char *n_dig_str = (char *)malloc(n_cv_digs + 1);
+        memcpy(n_dig_str, start, n_cv_digs);
+        n_dig_str[n_cv_digs] = '\0';
+        int n_digs = strtol(n_dig_str, NULL, 10);
+        if (n_digs != 0) {
+            char *cv = (char *)malloc(n_digs + 1);
+            memcpy(cv, p + 1, n_digs);
+            cv[n_digs] = '\0';
+            mr_counted_value = strtol(cv, NULL, 10);
+            p = p + 1 + n_digs;
+            start = p + 1;
+        }
+        else {
+            mr_counted_value = -1;
+        }
+    }
+
+    action extract_label {
+        char *lbl_len_str = (char *)malloc(p - start + 1);
+        memcpy(lbl_len_str, start, p - start);
+        lbl_len_str[p - start] = '\0';
+        int len = strtol(lbl_len_str, NULL, 10);
+        mr_label = (char *)malloc(len + 1);
+        memcpy(mr_label, p + 1, len);
+        mr_label[len] = '\0';
+        p = p + 1 + len;
+        start = p + 1;
+    }
+
+    action extract_subvar {
+        int len = p - start;
+        char *subvar = (char *)malloc(len + 1);
+        memcpy(subvar, start, len);
+        subvar[len] = '\0';
+        start = p + 1;
+
+        mr_subvariables = realloc(mr_subvariables, sizeof(char *) * (mr_subvar_count + 1));
+        mr_subvariables[mr_subvar_count++] = subvar;
+    }
+
+    name = (alnum | '_')+ '=' > extract_mr_name;
+    type = ('C' | 'D'){1} > extract_mr_type;
+    counted_value = digit* ' ' > extract_counted_value;
+    label = digit+ ' '+ > extract_label;
+
+    nc = (alnum | '_'); # name character
+    end = (space | '\0'); # token terminator
+    subvariable = (nc+ end >extract_subvar);
+
+    name_extractor := name type counted_value label subvariable+;
+}%%
+
+%% write data;
+
+readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+
+    // Variables needed for Ragel operation
+    int cs = 0;
+    char *p = (char *)line;
+    char *start = p;
+    char *pe = p + strlen(p) + 1;
+
+    // Variables needed for passing Ragel intermediate results
+    char mr_type;
+    int mr_counted_value;
+    int mr_subvar_count;
+    char **mr_subvariables = NULL;
+    char *mr_name = NULL;
+    char *mr_label = NULL;
+
+    // Execute Ragel finite state machine (FSM)
+    %% write init;
+    %% write exec;
+
+    // Check if FSM finished successfully
+    if (cs < %%{ write first_final; }%% || p != pe) {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+
+    // Assign parsed values to output parameter
+    result->name = strdup(mr_name);
+    result->label = strdup(mr_label);
+    result->type = mr_type;
+    result->counted_value = mr_counted_value;
+    result->subvariables = mr_subvariables;
+    result->num_subvars = mr_subvar_count;
+    if (result->type == 'D') {
+        result->is_dichotomy = 1;
+    }
+
+cleanup:
+    if (retval != READSTAT_OK) {
+        if (mr_subvariables != NULL) {
+            for (int i = 0; i < mr_subvar_count; i++) {
+                if (mr_subvariables[i] != NULL) free(mr_subvariables[i]);
+            }
+            free(mr_subvariables);
+        }
+        if (mr_name != NULL) free(mr_name);
+        if (mr_label != NULL) free(mr_label);
+    }
+    return retval;
+}
+
+
+readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+    *result = (mr_set_t){0};
+
+    return extract_mr_data(line, result);
+}

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -143,7 +143,10 @@ readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
         mln[p - start - 1] = '\0';
         *mr_sets = realloc(*mr_sets, ((*n_mr_lines) + 1) * sizeof(mr_set_t));
         retval = parse_mr_line(mln, &(*mr_sets)[*n_mr_lines]);
-        if (retval != READSTAT_OK) goto cleanup;
+        if (retval != READSTAT_OK) {
+            if (mln == NULL) free(mln);
+            goto cleanup;
+        }
         (*n_mr_lines)++;
         start = p + 1;
     }

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -8,7 +8,7 @@
     machine mr_name_and_label;
 
     action extract_mr_name {
-        mr_name = (char *)readstat_malloc(p - start + 1);
+        mr_name = readstat_malloc(p - start + 1);
         memcpy(mr_name, start, p - start);
         mr_name[p - start] = '\0';
     }
@@ -20,12 +20,12 @@
 
     action extract_counted_value {
         int n_cv_digs = p - start;
-        char *n_dig_str = (char *)readstat_malloc(n_cv_digs + 1);
+        char *n_dig_str = readstat_malloc(n_cv_digs + 1);
         memcpy(n_dig_str, start, n_cv_digs);
         n_dig_str[n_cv_digs] = '\0';
         int n_digs = strtol(n_dig_str, NULL, 10);
         if (n_digs != 0) {
-            char *cv = (char *)readstat_malloc(n_digs + 1);
+            char *cv = readstat_malloc(n_digs + 1);
             memcpy(cv, p + 1, n_digs);
             cv[n_digs] = '\0';
             mr_counted_value = strtol(cv, NULL, 10);
@@ -38,11 +38,11 @@
     }
 
     action extract_label {
-        char *lbl_len_str = (char *)readstat_malloc(p - start + 1);
+        char *lbl_len_str = readstat_malloc(p - start + 1);
         memcpy(lbl_len_str, start, p - start);
         lbl_len_str[p - start] = '\0';
         int len = strtol(lbl_len_str, NULL, 10);
-        mr_label = (char *)readstat_malloc(len + 1);
+        mr_label = readstat_malloc(len + 1);
         memcpy(mr_label, p + 1, len);
         mr_label[len] = '\0';
         p = p + 1 + len;
@@ -51,7 +51,7 @@
 
     action extract_subvar {
         int len = p - start;
-        char *subvar = (char *)readstat_malloc(len + 1);
+        char *subvar = readstat_malloc(len + 1);
         memcpy(subvar, start, len);
         subvar[len] = '\0';
         start = p + 1;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -232,9 +232,9 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;
     }
-    char *endptr;
+    char *endptr = NULL;
     size_t count = strtoul(digit_start, &endptr, 10);
-    if (endptr == digit_start || count == 0) {
+    if (endptr == digit_start) {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;
     }

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -149,6 +149,7 @@ static readstat_error_t sav_parse_long_string_value_labels_record(const void *da
 static readstat_error_t sav_parse_long_string_missing_values_record(const void *data, size_t size, size_t count, sav_ctx_t *ctx);
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx);
 
+
 static mr_set_t parse_mr_line(const char *line) {
     const char *equals_pos = strchr(line, '=');
     mr_set_t result;
@@ -178,7 +179,6 @@ static mr_set_t parse_mr_line(const char *line) {
                 next_part++;
             }
             result.counted_value = (int)strtol(digit_start, NULL, 10);
-            printf("\nFinal counted value is: %d\n", result.counted_value);
             if (*next_part != ' ' && *next_part != '\0') {
                 fprintf(stderr, "Expected a space or end of string after the counted value\n");
                 return result;
@@ -207,7 +207,6 @@ static mr_set_t parse_mr_line(const char *line) {
         }
         size_t count = strtoul(digit_start, NULL, 10);
         next_part++; // Move past the space after the digits
-        printf("count: %zu\n", count);
         if (strlen(next_part) < count) {
             fprintf(stderr, "Not enough characters available to read the specified count\n");
             free(result.name);
@@ -230,10 +229,6 @@ static mr_set_t parse_mr_line(const char *line) {
 
         // Move the next_part pointer past the read characters
         next_part += count;
-
-        // Output the actual label for debugging
-        printf("label: %s\n", result.label);
-
         if (*next_part != ' ') {
             fprintf(stderr, "Expected a space after the label\n");
             free(result.label);
@@ -306,7 +301,8 @@ static mr_set_t parse_mr_line(const char *line) {
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx) {
     readstat_error_t retval = READSTAT_OK;
 
-    char *mr_string = readstat_malloc(data_len);
+    char *mr_string = readstat_malloc(data_len + 1);
+    mr_string[data_len] = '\0';
     if (mr_string == NULL) return READSTAT_ERROR_MALLOC;
 
     if (ctx->io->read(mr_string, data_len, ctx->io->io_ctx) < data_len) {
@@ -319,7 +315,7 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
     char *token = strtok(mr_string, "$\n");
     int num_lines = 0;
     while (token != NULL) {
-        ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t *));
+        ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t));
         ctx->mr_sets[num_lines] = parse_mr_line(token);
         num_lines++;
         token = strtok(NULL, "$\n");
@@ -1852,6 +1848,35 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
             goto cleanup;
 
         metadata.file_label = ctx->file_label;
+
+        // Replace short MR names with long names
+        ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
+        for (size_t i = 0; i < ctx->var_count; i++) {
+            spss_varinfo_t *current_varinfo = ctx->varinfo[i];
+            if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
+                ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
+            }
+        }
+        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+            mr_set_t mr = ctx->mr_sets[i];
+            for (size_t j = 0; j < mr.num_subvars; j++) {
+                char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
+                for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
+                    sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
+                }
+                spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
+                if (info) {
+                    free(mr.subvariables[j]);
+                    mr.subvariables[j] = info->longname;
+                }
+            }
+        }
+        if (var_dict)
+            ck_hash_table_free(var_dict);
+
+        metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
+        metadata.mr_sets = ctx->mr_sets;
+
         metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
         metadata.mr_sets = ctx->mr_sets;
 
@@ -1867,36 +1892,6 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
     if ((retval = sav_handle_variables(ctx)) != READSTAT_OK)
         goto cleanup;
 
-    ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
-    for (size_t i = 0; i < ctx->varinfo_capacity; i++) {
-        spss_varinfo_t *current_varinfo = ctx->varinfo[i];
-        if (current_varinfo != NULL) {
-            ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
-        }
-    }
-    for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
-        mr_set_t mr = ctx->mr_sets[i];
-        for (size_t j = 0; j < mr.num_subvars; j++) {
-            if (mr.type == 'C') {
-                char* sv_name_upper = malloc(strlen(mr.subvariables[i]) + 1);
-                for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
-                    sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
-                }
-                sv_name_upper[strlen(mr.subvariables[j])] = '\0';
-                spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
-                if (info) {
-                    free(mr.subvariables[j]);
-                    mr.subvariables[j] = malloc(strlen(info->longname) + 1);
-                    if (mr.subvariables[j] == NULL) {
-                        continue;
-                    }
-                    strcpy(mr.subvariables[j], info->longname);
-                }
-            }
-        }
-    }
-    if (var_dict)
-        ck_hash_table_free(var_dict);
 
     if ((retval = sav_handle_fweight(ctx)) != READSTAT_OK)
         goto cleanup;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -303,6 +303,10 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
         retval = READSTAT_ERROR_PARSE;
         goto cleanup;
     }
+    if (mr_string[0] != '$') {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
 
     char *token = strtok(mr_string, "$\n");
     int num_lines = 0;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1,7 +1,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <math.h>
@@ -31,8 +30,9 @@
 #define VERY_LONG_STRING_MAX_LENGTH INT_MAX
 
 #ifdef _WIN32
-#define strtok_r(s,d,p) strtok_s(s,d,p)
+#define strtok_r strtok_s
 #endif
+#include <string.h>
 
 /* Others defined in table below */
 

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <math.h>
@@ -29,10 +30,9 @@
 #define DATA_BUFFER_SIZE    65536
 #define VERY_LONG_STRING_MAX_LENGTH INT_MAX
 
-#ifdef _WIN32
-#define strtok_r strtok_s
-#endif
-#include <string.h>
+// #ifdef _WIN32
+// #define strtok_r(s,d,p) strtok_s(s,d,p)
+// #endif
 
 /* Others defined in table below */
 
@@ -172,11 +172,9 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
         goto cleanup;
     }
 
-    char *saveptr;
-    // fprintf(stderr, "Debug: mr string: '%s'\n", mr_string);
-    char *token = strtok_r(mr_string, "$\n", &saveptr);
-    // fprintf(stderr, "Debug: fst token: '%s'\n", token);
-    // char *token = strtok(mr_string, "$\n");
+    // char *saveptr;
+    // char *token = strtok_r(mr_string, "$\n", &saveptr);
+    char *token = strtok(mr_string, "$\n");
 
     int num_lines = 0;
     while (token != NULL) {
@@ -184,15 +182,11 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
             retval = READSTAT_ERROR_MALLOC;
             goto cleanup;
         }
-        fprintf(stderr, "before parsing line\n");
-        fprintf(stderr, "token: '%s'\n", token);
         retval = parse_mr_line(token, &ctx->mr_sets[num_lines]);
         if (retval != READSTAT_OK) goto cleanup;
         num_lines++;
-        fprintf(stderr, "making next token\n");
-        token = strtok_r(NULL, "$\n", &saveptr);
-        // token = strtok(NULL, "$\n");
-        fprintf(stderr, "Debug: nxt token: '%s'\n", token);
+        // token = strtok_r(NULL, "$\n", &saveptr);
+        token = strtok(NULL, "$\n");
     }
     ctx->multiple_response_sets_length = num_lines;
 

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -149,26 +149,26 @@ static readstat_error_t sav_parse_long_string_value_labels_record(const void *da
 static readstat_error_t sav_parse_long_string_missing_values_record(const void *data, size_t size, size_t count, sav_ctx_t *ctx);
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx);
 
-static readstat_error_t parse_mr_counted_value(const char **next_part, mr_set_t *result) {
+static readstat_error_t parse_mr_counted_value(const char *line, mr_set_t *result) {
     readstat_error_t retval = READSTAT_OK;
     if (result->type == 'D') {
         result->is_dichotomy = 1;
-        const char *digit_start = (*next_part);
-        while (*(*next_part) != ' ' && *(*next_part) != '\0') {
-            (*next_part)++;
+        const char *digit_start = line;
+        while (*line != ' ' && *line != '\0') {
+            line++;
         }
         int internal_count = (int)strtol(digit_start, NULL, 10);
-        if (*(*next_part) != ' ') {
+        if (*line != ' ') {
             retval = READSTAT_ERROR_BAD_MR_STRING;
             goto cleanup;
         }
-        (*next_part)++;
-        digit_start = (*next_part);
-        for (int i = 0; i < internal_count && isdigit(*(*next_part)); i++) {
-            (*next_part)++;
+        line++;
+        digit_start = line;
+        for (int i = 0; i < internal_count && isdigit(*line); i++) {
+            line++;
         }
         result->counted_value = (int)strtol(digit_start, NULL, 10);
-        if (*(*next_part) != ' ' && *(*next_part) != '\0') {
+        if (*line != ' ' && *line != '\0') {
             retval = READSTAT_ERROR_BAD_MR_STRING;
             goto cleanup;
         }
@@ -193,14 +193,40 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
 
     result->type = equals_pos[1];
     int name_length = equals_pos - line;
-    if ((result->name = malloc(name_length + 1)) == NULL) {
+    result->name = malloc(name_length + 1);
+    if (result->name == NULL) {
         retval = READSTAT_ERROR_MALLOC;
         goto cleanup;
     }
     strncpy(result->name, line, name_length);
     result->name[name_length] = '\0';
     const char *next_part = equals_pos + 2;  // Start after the '=' and type character
-    if ((retval = parse_mr_counted_value(&next_part, result)) != READSTAT_OK) goto cleanup;
+    if (result->type == 'D') {
+        result->is_dichotomy = 1;
+        const char *digit_start = next_part;
+        while (*next_part != ' ' && *next_part != '\0') {
+            next_part++;
+        }
+        int internal_count = (int)strtol(digit_start, NULL, 10);
+        if (*next_part != ' ') {
+            retval = READSTAT_ERROR_BAD_MR_STRING;
+            goto cleanup;
+        }
+        next_part++;
+        digit_start = next_part;
+        for (int i = 0; i < internal_count && isdigit(*next_part); i++) {
+            next_part++;
+        }
+        result->counted_value = (int)strtol(digit_start, NULL, 10);
+        if (*next_part != ' ' && *next_part != '\0') {
+            retval = READSTAT_ERROR_BAD_MR_STRING;
+            goto cleanup;
+        }
+    }
+    else if (result->type == 'C') {
+        result->is_dichotomy = 0;
+        result->counted_value = -1;
+    }
     if (*next_part != ' ') {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;
@@ -221,6 +247,7 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
         goto cleanup;
     }
 
+    // Allocate memory for label
     result->label = malloc(count + 1);  // +1 for the null-terminator
     if (result->label == NULL) {
         retval = READSTAT_ERROR_MALLOC;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -232,9 +232,7 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
     }
     next_part++;
     const char *digit_start = next_part;
-    while (isdigit(*next_part)) {
-        next_part++;
-    }
+    while (isdigit(*next_part)) next_part++;
     if (*next_part != ' ') {
         retval = READSTAT_ERROR_BAD_MR_STRING;
         goto cleanup;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -317,6 +317,7 @@ cleanup:
 }
 
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx) {
+    return READSTAT_OK; // hatchet
     readstat_error_t retval = READSTAT_OK;
 
     char *mr_string = readstat_malloc(data_len + 1);
@@ -1879,46 +1880,47 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
         metadata.file_label = ctx->file_label;
 
         // Replace short MR names with long names
-        ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
-        for (size_t i = 0; i < ctx->var_count; i++) {
-            spss_varinfo_t *current_varinfo = ctx->varinfo[i];
-            if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
-                ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
-            }
-        }
-        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
-            mr_set_t mr = ctx->mr_sets[i];
-            for (size_t j = 0; j < mr.num_subvars; j++) {
-                char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
-                if (sv_name_upper == NULL) {
-                    retval = READSTAT_ERROR_MALLOC;
-                    goto cleanup;
-                }
-                sv_name_upper[strlen(mr.subvariables[j])] = '\0';
-                for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
-                    sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
-                }
-                spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
-                if (info) {
-                    free(mr.subvariables[j]);
-                    // mr.subvariables[j] = NULL;
-                    if ((mr.subvariables[j] = readstat_malloc(strlen(info->longname) + 1)) == NULL) {
-                        retval = READSTAT_ERROR_MALLOC;
-                        goto cleanup;
-                    }
-                    // mr.subvariables[j][strlen(info->longname)] = '\0';
-                    strcpy(mr.subvariables[j], info->longname);
-                    // mr.subvariables[j] = info->longname;
-                }
-                free(sv_name_upper);
-                // sv_name_upper = NULL;
-            }
-        }
-        if (var_dict)
-            ck_hash_table_free(var_dict);
+        // Hatchet !!!
+        // ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
+        // for (size_t i = 0; i < ctx->var_count; i++) {
+        //     spss_varinfo_t *current_varinfo = ctx->varinfo[i];
+        //     if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
+        //         ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
+        //     }
+        // }
+        // for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+        //     mr_set_t mr = ctx->mr_sets[i];
+        //     for (size_t j = 0; j < mr.num_subvars; j++) {
+        //         char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
+        //         if (sv_name_upper == NULL) {
+        //             retval = READSTAT_ERROR_MALLOC;
+        //             goto cleanup;
+        //         }
+        //         sv_name_upper[strlen(mr.subvariables[j])] = '\0';
+        //         for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
+        //             sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
+        //         }
+        //         spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
+        //         if (info) {
+        //             free(mr.subvariables[j]);
+        //             // mr.subvariables[j] = NULL;
+        //             if ((mr.subvariables[j] = readstat_malloc(strlen(info->longname) + 1)) == NULL) {
+        //                 retval = READSTAT_ERROR_MALLOC;
+        //                 goto cleanup;
+        //             }
+        //             // mr.subvariables[j][strlen(info->longname)] = '\0';
+        //             strcpy(mr.subvariables[j], info->longname);
+        //             // mr.subvariables[j] = info->longname;
+        //         }
+        //         free(sv_name_upper);
+        //         // sv_name_upper = NULL;
+        //     }
+        // }
+        // if (var_dict)
+        //     ck_hash_table_free(var_dict);
 
-        metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
-        metadata.mr_sets = ctx->mr_sets;
+        // metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
+        // metadata.mr_sets = ctx->mr_sets;
 
         if (ctx->handle.metadata(&metadata, ctx->user_ctx) != READSTAT_HANDLER_OK) {
             retval = READSTAT_ERROR_USER_ABORT;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -164,7 +164,7 @@ static readstat_error_t parse_mr_counted_value(const char **next_part, mr_set_t 
         }
         (*next_part)++;
         digit_start = (*next_part);
-        for (int i = 0; i < internal_count && isdigit(*(*next_part)); i++) {
+        for (int i = 0; i < internal_count && isdigit((unsigned char)*(*next_part)); i++) {
             (*next_part)++;
         }
         result->counted_value = (int)strtol(digit_start, NULL, 10);
@@ -180,6 +180,7 @@ static readstat_error_t parse_mr_counted_value(const char **next_part, mr_set_t 
 cleanup:
     return retval;
 }
+
 
 static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
     readstat_error_t retval = READSTAT_OK;
@@ -207,7 +208,7 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
     }
     next_part++;
     const char *digit_start = next_part;
-    while (isdigit(*next_part)) {
+    while (isdigit((unsigned char)*next_part)) {
         next_part++;
     }
     if (*next_part != ' ') {

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1884,47 +1884,46 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
         metadata.file_label = ctx->file_label;
 
         // Replace short MR names with long names
-        // Hatchet !!!
-        // ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
-        // for (size_t i = 0; i < ctx->var_count; i++) {
-        //     spss_varinfo_t *current_varinfo = ctx->varinfo[i];
-        //     if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
-        //         ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
-        //     }
-        // }
-        // for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
-        //     mr_set_t mr = ctx->mr_sets[i];
-        //     for (size_t j = 0; j < mr.num_subvars; j++) {
-        //         char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
-        //         if (sv_name_upper == NULL) {
-        //             retval = READSTAT_ERROR_MALLOC;
-        //             goto cleanup;
-        //         }
-        //         sv_name_upper[strlen(mr.subvariables[j])] = '\0';
-        //         for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
-        //             sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
-        //         }
-        //         spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
-        //         if (info) {
-        //             free(mr.subvariables[j]);
-        //             // mr.subvariables[j] = NULL;
-        //             if ((mr.subvariables[j] = readstat_malloc(strlen(info->longname) + 1)) == NULL) {
-        //                 retval = READSTAT_ERROR_MALLOC;
-        //                 goto cleanup;
-        //             }
-        //             // mr.subvariables[j][strlen(info->longname)] = '\0';
-        //             strcpy(mr.subvariables[j], info->longname);
-        //             // mr.subvariables[j] = info->longname;
-        //         }
-        //         free(sv_name_upper);
-        //         // sv_name_upper = NULL;
-        //     }
-        // }
-        // if (var_dict)
-        //     ck_hash_table_free(var_dict);
+        ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
+        for (size_t i = 0; i < ctx->var_count; i++) {
+            spss_varinfo_t *current_varinfo = ctx->varinfo[i];
+            if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
+                ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
+            }
+        }
+        for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+            mr_set_t mr = ctx->mr_sets[i];
+            for (size_t j = 0; j < mr.num_subvars; j++) {
+                char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
+                if (sv_name_upper == NULL) {
+                    retval = READSTAT_ERROR_MALLOC;
+                    goto cleanup;
+                }
+                sv_name_upper[strlen(mr.subvariables[j])] = '\0';
+                for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
+                    sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
+                }
+                spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
+                if (info) {
+                    free(mr.subvariables[j]);
+                    // mr.subvariables[j] = NULL;
+                    if ((mr.subvariables[j] = readstat_malloc(strlen(info->longname) + 1)) == NULL) {
+                        retval = READSTAT_ERROR_MALLOC;
+                        goto cleanup;
+                    }
+                    // mr.subvariables[j][strlen(info->longname)] = '\0';
+                    strcpy(mr.subvariables[j], info->longname);
+                    // mr.subvariables[j] = info->longname;
+                }
+                free(sv_name_upper);
+                // sv_name_upper = NULL;
+            }
+        }
+        if (var_dict)
+            ck_hash_table_free(var_dict);
 
-        // metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
-        // metadata.mr_sets = ctx->mr_sets;
+        metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
+        metadata.mr_sets = ctx->mr_sets;
 
         if (ctx->handle.metadata(&metadata, ctx->user_ctx) != READSTAT_HANDLER_OK) {
             retval = READSTAT_ERROR_USER_ABORT;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -149,153 +149,144 @@ static readstat_error_t sav_parse_long_string_value_labels_record(const void *da
 static readstat_error_t sav_parse_long_string_missing_values_record(const void *data, size_t size, size_t count, sav_ctx_t *ctx);
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx);
 
+static readstat_error_t parse_mr_counted_value(const char **next_part, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+    if (result->type == 'D') {
+        result->is_dichotomy = 1;
+        const char *digit_start = (*next_part);
+        while (*(*next_part) != ' ' && *(*next_part) != '\0') {
+            (*next_part)++;
+        }
+        int internal_count = (int)strtol(digit_start, NULL, 10);
+        if (*(*next_part) != ' ') {
+            retval = READSTAT_ERROR_BAD_MR_STRING;
+            goto cleanup;
+        }
+        (*next_part)++;
+        digit_start = (*next_part);
+        for (int i = 0; i < internal_count && isdigit(*(*next_part)); i++) {
+            (*next_part)++;
+        }
+        result->counted_value = (int)strtol(digit_start, NULL, 10);
+        if (*(*next_part) != ' ' && *(*next_part) != '\0') {
+            retval = READSTAT_ERROR_BAD_MR_STRING;
+            goto cleanup;
+        }
+    }
+    else if (result->type == 'C') {
+        result->is_dichotomy = 0;
+        result->counted_value = -1;
+    }
+cleanup:
+    return retval;
+}
 
-static mr_set_t parse_mr_line(const char *line) {
+static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
+    readstat_error_t retval = READSTAT_OK;
+    *result = (mr_set_t){0};
+
     const char *equals_pos = strchr(line, '=');
-    mr_set_t result;
-
-    if (equals_pos != NULL && equals_pos[1] != '\0') {
-        result.type = equals_pos[1];
-        int name_length = equals_pos - line;
-        result.name = malloc(name_length + 1);
-        strncpy(result.name, line, name_length);
-        result.name[name_length] = '\0';
-        const char *next_part = equals_pos + 2;  // Start after the '=' and type character
-        if (result.type == 'D') {
-            result.is_dichotomy = 1;
-            const char *digit_start = next_part;
-            while (*next_part != ' ' && *next_part != '\0') {
-                next_part++;
-            }
-            int internal_count = (int)strtol(digit_start, NULL, 10);
-            if (*next_part == ' ') {
-                next_part++;
-            } else {
-                fprintf(stderr, "Expected a space after the internal count\n");
-                return result;
-            }
-            digit_start = next_part;
-            for (int i = 0; i < internal_count && isdigit(*next_part); i++) {
-                next_part++;
-            }
-            result.counted_value = (int)strtol(digit_start, NULL, 10);
-            if (*next_part != ' ' && *next_part != '\0') {
-                fprintf(stderr, "Expected a space or end of string after the counted value\n");
-                return result;
-            }
-        }
-        else if (result.type == 'C') {
-            result.is_dichotomy = 0;
-            result.counted_value = -1;
-        }
-        if (*next_part != ' ') {
-            fprintf(stderr, "Expected a space after type 'C'\n");
-            free(result.name);
-            result.name = NULL;
-            return result;
-        }
-        next_part++;
-        const char *digit_start = next_part;
-        while (isdigit(*next_part)) {
-            next_part++;
-        }
-        if (*next_part != ' ') {
-            fprintf(stderr, "Expected a space after the digits\n");
-            free(result.name);
-            result.name = NULL;
-            return result;
-        }
-        size_t count = strtoul(digit_start, NULL, 10);
-        next_part++; // Move past the space after the digits
-        if (strlen(next_part) < count) {
-            fprintf(stderr, "Not enough characters available to read the specified count\n");
-            free(result.name);
-            result.name = NULL;
-            return result;
-        }
-
-        // Allocate memory for label
-        result.label = malloc(count + 1);  // +1 for the null-terminator
-        if (result.label == NULL) {
-            fprintf(stderr, "Failed to allocate memory for label\n");
-            free(result.name);
-            result.name = NULL;
-            return result;
-        }
-
-        // Copy the specified number of characters into label
-        strncpy(result.label, next_part, count);
-        result.label[count] = '\0';  // Null-terminate the string
-
-        // Move the next_part pointer past the read characters
-        next_part += count;
-        if (*next_part != ' ') {
-            fprintf(stderr, "Expected a space after the label\n");
-            free(result.label);
-            result.label = NULL;
-            return result;
-        }
-        next_part++; // Move past the space
-        char **subvariables = NULL;
-        int subvar_count = 0;
-        while (*next_part) {
-            if (*next_part == ' ') {  // Skip any extra spaces
-                next_part++;
-                continue;
-            }
-
-            const char *start = next_part;
-            while (*next_part && *next_part != ' ') {
-                next_part++;  // Move to the end of the current subvariable
-            }
-
-            size_t length = next_part - start;
-            char *subvariable = malloc(length + 1);  // Allocate memory for the subvariable
-            if (subvariable == NULL) {
-                fprintf(stderr, "Failed to allocate memory for a subvariable\n");
-                // Cleanup previously allocated subvariables
-                for (int i = 0; i < subvar_count; i++) {
-                    free(subvariables[i]);
-                }
-                free(subvariables);
-                free(result.label);
-                result.label = NULL;
-                return result;
-            }
-            strncpy(subvariable, start, length);
-            subvariable[length] = '\0';  // Null-terminate the string
-
-            // Allocate/resize the subvariables array
-            char **temp = realloc(subvariables, (subvar_count + 1) * sizeof(char *));
-            if (temp == NULL) {
-                fprintf(stderr, "Failed to allocate memory for subvariables array\n");
-                free(subvariable);
-                // Cleanup previously allocated subvariables
-                for (int i = 0; i < subvar_count; i++) {
-                    free(subvariables[i]);
-                }
-                free(subvariables);
-                free(result.label);
-                result.label = NULL;
-                return result;
-            }
-            subvariables = temp;
-            subvariables[subvar_count++] = subvariable;  // Add the new subvariable to the array
-
-            if (*next_part == ' ') {
-                next_part++;  // Move past the space
-            }
-        }
-
-        result.subvariables = subvariables;
-        result.num_subvars = subvar_count;
-
-    } else {
-        result.type = '\0'; // Use a default type or an error indicator
-        result.name = NULL;
+    if (equals_pos == NULL || equals_pos[1] == '\0') {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
     }
 
-    return result;
+    result->type = equals_pos[1];
+    int name_length = equals_pos - line;
+    if ((result->name = malloc(name_length + 1)) == NULL) {
+        retval = READSTAT_ERROR_MALLOC;
+        goto cleanup;
+    }
+    strncpy(result->name, line, name_length);
+    result->name[name_length] = '\0';
+    const char *next_part = equals_pos + 2;  // Start after the '=' and type character
+    if ((retval = parse_mr_counted_value(&next_part, result)) != READSTAT_OK) goto cleanup;
+    if (*next_part != ' ') {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+    next_part++;
+    const char *digit_start = next_part;
+    while (isdigit(*next_part)) {
+        next_part++;
+    }
+    if (*next_part != ' ') {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+    size_t count = strtoul(digit_start, NULL, 10);
+    next_part++; // Move past the space after the digits
+    if (strlen(next_part) < count) {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+
+    result->label = malloc(count + 1);  // +1 for the null-terminator
+    if (result->label == NULL) {
+        retval = READSTAT_ERROR_MALLOC;
+        goto cleanup;
+    }
+    strncpy(result->label, next_part, count);
+    result->label[count] = '\0';
+
+    next_part += count;
+    if (*next_part != ' ') {
+        retval = READSTAT_ERROR_BAD_MR_STRING;
+        goto cleanup;
+    }
+    next_part++;
+
+    char **subvariables = NULL;
+    int subvar_count = 0;
+    while (*next_part) {
+        if (*next_part == ' ') {  // Skip any extra spaces
+            next_part++;
+            continue;
+        }
+
+        const char *start = next_part;
+        while (*next_part && *next_part != ' ') {
+            next_part++;  // Move to the end of the current subvariable
+        }
+
+        size_t length = next_part - start;
+        char *subvariable = malloc(length + 1);  // Allocate memory for the subvariable
+        if (subvariable == NULL) {
+            retval = READSTAT_ERROR_MALLOC;
+            for (int i = 0; i < subvar_count; i++) {
+                free(subvariables[i]);
+            }
+            free(subvariables);
+            free(result->label);
+            result->label = NULL;
+            goto cleanup;
+        }
+        strncpy(subvariable, start, length);
+        subvariable[length] = '\0';  // Null-terminate the string
+
+        char **temp = realloc(subvariables, (subvar_count + 1) * sizeof(char *));
+        if (temp == NULL) {
+            retval = READSTAT_ERROR_MALLOC;
+            free(subvariable);
+            for (int i = 0; i < subvar_count; i++) {
+                free(subvariables[i]);
+            }
+            free(subvariables);
+            free(result->label);
+            result->label = NULL;
+            goto cleanup;
+        }
+        subvariables = temp;
+        subvariables[subvar_count++] = subvariable;  // Add the new subvariable to the array
+
+        if (*next_part == ' ') next_part++; // Move past the space
+    }
+
+    result->subvariables = subvariables;
+    result->num_subvars = subvar_count;
+
+cleanup:
+    return retval;
 }
 
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx) {
@@ -303,25 +294,28 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
 
     char *mr_string = readstat_malloc(data_len + 1);
     mr_string[data_len] = '\0';
-    if (mr_string == NULL) return READSTAT_ERROR_MALLOC;
+    if (mr_string == NULL) {
+        retval = READSTAT_ERROR_MALLOC;
+        goto cleanup;
+    }
 
     if (ctx->io->read(mr_string, data_len, ctx->io->io_ctx) < data_len) {
         retval = READSTAT_ERROR_PARSE;
-        free(mr_string);
-        mr_string = NULL;
-        return retval;
+        goto cleanup;
     }
 
     char *token = strtok(mr_string, "$\n");
     int num_lines = 0;
     while (token != NULL) {
         ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t));
-        ctx->mr_sets[num_lines] = parse_mr_line(token);
+        retval = parse_mr_line(token, &ctx->mr_sets[num_lines]);
+        if (retval != READSTAT_OK) goto cleanup;
         num_lines++;
         token = strtok(NULL, "$\n");
     }
     ctx->multiple_response_sets_length = num_lines;
 
+cleanup:
     return retval;
 }
 
@@ -896,10 +890,6 @@ static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len
             }
             if (++offset == col_info->width) {
                 if (++segment_offset < var_info->n_segments) {
-                    if (raw_str_used == 0) {
-                        retval = READSTAT_ERROR_PARSE;
-                        goto done;
-                    }
                     raw_str_used--;
                 }
                 offset = 0;
@@ -1873,9 +1863,6 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
         }
         if (var_dict)
             ck_hash_table_free(var_dict);
-
-        metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
-        metadata.mr_sets = ctx->mr_sets;
 
         metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
         metadata.mr_sets = ctx->mr_sets;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -307,7 +307,10 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
     char *token = strtok(mr_string, "$\n");
     int num_lines = 0;
     while (token != NULL) {
-        ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t));
+        if ((ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t))) == NULL) {
+            retval = READSTAT_ERROR_MALLOC;
+            goto cleanup;
+        }
         retval = parse_mr_line(token, &ctx->mr_sets[num_lines]);
         if (retval != READSTAT_OK) goto cleanup;
         num_lines++;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1868,6 +1868,7 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
                     free(mr.subvariables[j]);
                     mr.subvariables[j] = info->longname;
                 }
+                free(sv_name_upper);
             }
         }
         if (var_dict)

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -193,8 +193,7 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
 
     result->type = equals_pos[1];
     int name_length = equals_pos - line;
-    result->name = malloc(name_length + 1);
-    if (result->name == NULL) {
+    if ((result->name = malloc(name_length + 1)) == NULL) {
         retval = READSTAT_ERROR_MALLOC;
         goto cleanup;
     }

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -319,6 +319,7 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
     ctx->multiple_response_sets_length = num_lines;
 
 cleanup:
+    free(mr_string);
     return retval;
 }
 

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -14,6 +14,7 @@
 #include "../readstat_iconv.h"
 #include "../readstat_convert.h"
 #include "../readstat_malloc.h"
+#include "../CKHashTable.h"
 
 #include "readstat_sav.h"
 #include "readstat_sav_compress.h"
@@ -145,6 +146,187 @@ static readstat_error_t sav_parse_variable_display_parameter_record(sav_ctx_t *c
 static readstat_error_t sav_parse_machine_integer_info_record(const void *data, size_t data_len, sav_ctx_t *ctx);
 static readstat_error_t sav_parse_long_string_value_labels_record(const void *data, size_t size, size_t count, sav_ctx_t *ctx);
 static readstat_error_t sav_parse_long_string_missing_values_record(const void *data, size_t size, size_t count, sav_ctx_t *ctx);
+static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx);
+
+static mr_set_t parse_mr_line(const char *line) {
+    const char *equals_pos = strchr(line, '=');
+    mr_set_t result;
+
+    if (equals_pos != NULL && equals_pos[1] != '\0') {
+        result.type = equals_pos[1];
+        int name_length = equals_pos - line;
+        result.name = malloc(name_length + 1);
+        strncpy(result.name, line, name_length);
+        result.name[name_length] = '\0';
+        const char *next_part = equals_pos + 2;  // Start after the '=' and type character
+        if (result.type == 'D') {
+            result.is_dichotomy = 1;
+            const char *digit_start = next_part;
+            while (*next_part != ' ' && *next_part != '\0') {
+                next_part++;
+            }
+            int internal_count = (int)strtol(digit_start, NULL, 10);
+            if (*next_part == ' ') {
+                next_part++;
+            } else {
+                fprintf(stderr, "Expected a space after the internal count\n");
+                return result;
+            }
+            digit_start = next_part;
+            for (int i = 0; i < internal_count && isdigit(*next_part); i++) {
+                next_part++;
+            }
+            result.counted_value = (int)strtol(digit_start, NULL, 10);
+            printf("\nFinal counted value is: %d\n", result.counted_value);
+            if (*next_part != ' ' && *next_part != '\0') {
+                fprintf(stderr, "Expected a space or end of string after the counted value\n");
+                return result;
+            }
+        }
+        else if (result.type == 'C') {
+            result.is_dichotomy = 0;
+            result.counted_value = -1;
+        }
+        if (*next_part != ' ') {
+            fprintf(stderr, "Expected a space after type 'C'\n");
+            free(result.name);
+            result.name = NULL;
+            return result;
+        }
+        next_part++;
+        const char *digit_start = next_part;
+        while (isdigit(*next_part)) {
+            next_part++;
+        }
+        if (*next_part != ' ') {
+            fprintf(stderr, "Expected a space after the digits\n");
+            free(result.name);
+            result.name = NULL;
+            return result;
+        }
+        size_t count = strtoul(digit_start, NULL, 10);
+        next_part++; // Move past the space after the digits
+        printf("count: %zu\n", count);
+        if (strlen(next_part) < count) {
+            fprintf(stderr, "Not enough characters available to read the specified count\n");
+            free(result.name);
+            result.name = NULL;
+            return result;
+        }
+
+        // Allocate memory for label
+        result.label = malloc(count + 1);  // +1 for the null-terminator
+        if (result.label == NULL) {
+            fprintf(stderr, "Failed to allocate memory for label\n");
+            free(result.name);
+            result.name = NULL;
+            return result;
+        }
+
+        // Copy the specified number of characters into label
+        strncpy(result.label, next_part, count);
+        result.label[count] = '\0';  // Null-terminate the string
+
+        // Move the next_part pointer past the read characters
+        next_part += count;
+
+        // Output the actual label for debugging
+        printf("label: %s\n", result.label);
+
+        if (*next_part != ' ') {
+            fprintf(stderr, "Expected a space after the label\n");
+            free(result.label);
+            result.label = NULL;
+            return result;
+        }
+        next_part++; // Move past the space
+        char **subvariables = NULL;
+        int subvar_count = 0;
+        while (*next_part) {
+            if (*next_part == ' ') {  // Skip any extra spaces
+                next_part++;
+                continue;
+            }
+
+            const char *start = next_part;
+            while (*next_part && *next_part != ' ') {
+                next_part++;  // Move to the end of the current subvariable
+            }
+
+            size_t length = next_part - start;
+            char *subvariable = malloc(length + 1);  // Allocate memory for the subvariable
+            if (subvariable == NULL) {
+                fprintf(stderr, "Failed to allocate memory for a subvariable\n");
+                // Cleanup previously allocated subvariables
+                for (int i = 0; i < subvar_count; i++) {
+                    free(subvariables[i]);
+                }
+                free(subvariables);
+                free(result.label);
+                result.label = NULL;
+                return result;
+            }
+            strncpy(subvariable, start, length);
+            subvariable[length] = '\0';  // Null-terminate the string
+
+            // Allocate/resize the subvariables array
+            char **temp = realloc(subvariables, (subvar_count + 1) * sizeof(char *));
+            if (temp == NULL) {
+                fprintf(stderr, "Failed to allocate memory for subvariables array\n");
+                free(subvariable);
+                // Cleanup previously allocated subvariables
+                for (int i = 0; i < subvar_count; i++) {
+                    free(subvariables[i]);
+                }
+                free(subvariables);
+                free(result.label);
+                result.label = NULL;
+                return result;
+            }
+            subvariables = temp;
+            subvariables[subvar_count++] = subvariable;  // Add the new subvariable to the array
+
+            if (*next_part == ' ') {
+                next_part++;  // Move past the space
+            }
+        }
+
+        result.subvariables = subvariables;
+        result.num_subvars = subvar_count;
+
+    } else {
+        result.type = '\0'; // Use a default type or an error indicator
+        result.name = NULL;
+    }
+
+    return result;
+}
+
+static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx) {
+    readstat_error_t retval = READSTAT_OK;
+
+    char *mr_string = readstat_malloc(data_len);
+    if (mr_string == NULL) return READSTAT_ERROR_MALLOC;
+
+    if (ctx->io->read(mr_string, data_len, ctx->io->io_ctx) < data_len) {
+        retval = READSTAT_ERROR_PARSE;
+        free(mr_string);
+        mr_string = NULL;
+        return retval;
+    }
+
+    char *token = strtok(mr_string, "$\n");
+    int num_lines = 0;
+    while (token != NULL) {
+        ctx->mr_sets = realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t *));
+        ctx->mr_sets[num_lines] = parse_mr_line(token);
+        num_lines++;
+        token = strtok(NULL, "$\n");
+    }
+    ctx->multiple_response_sets_length = num_lines;
+
+    return retval;
+}
 
 static void sav_tag_missing_double(readstat_value_t *value, sav_ctx_t *ctx) {
     double fp_value = value->v.double_value;
@@ -1339,6 +1521,10 @@ static readstat_error_t sav_parse_records_pass1(sav_ctx_t *ctx) {
                     retval = sav_parse_machine_integer_info_record(data_buf, data_len, ctx);
                     if (retval != READSTAT_OK)
                         goto cleanup;
+                } else if (subtype == SAV_RECORD_SUBTYPE_MULTIPLE_RESPONSE_SETS) {
+                    retval = sav_read_multiple_response_sets(data_len, ctx);
+                    if (retval != READSTAT_OK)
+                        goto cleanup;
                 } else {
                     if (io->seek(data_len, READSTAT_SEEK_CUR, io->io_ctx) == -1) {
                         retval = READSTAT_ERROR_SEEK;
@@ -1665,6 +1851,8 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
             goto cleanup;
 
         metadata.file_label = ctx->file_label;
+        metadata.multiple_response_sets_length = ctx->multiple_response_sets_length;
+        metadata.mr_sets = ctx->mr_sets;
 
         if (ctx->handle.metadata(&metadata, ctx->user_ctx) != READSTAT_HANDLER_OK) {
             retval = READSTAT_ERROR_USER_ABORT;
@@ -1677,6 +1865,37 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
 
     if ((retval = sav_handle_variables(ctx)) != READSTAT_OK)
         goto cleanup;
+
+    ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
+    for (size_t i = 0; i < ctx->varinfo_capacity; i++) {
+        spss_varinfo_t *current_varinfo = ctx->varinfo[i];
+        if (current_varinfo != NULL) {
+            ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);
+        }
+    }
+    for (size_t i = 0; i < ctx->multiple_response_sets_length; i++) {
+        mr_set_t mr = ctx->mr_sets[i];
+        for (size_t j = 0; j < mr.num_subvars; j++) {
+            if (mr.type == 'C') {
+                char* sv_name_upper = malloc(strlen(mr.subvariables[i]) + 1);
+                for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
+                    sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
+                }
+                sv_name_upper[strlen(mr.subvariables[j])] = '\0';
+                spss_varinfo_t *info = (spss_varinfo_t *)ck_str_hash_lookup(sv_name_upper, var_dict);
+                if (info) {
+                    free(mr.subvariables[j]);
+                    mr.subvariables[j] = malloc(strlen(info->longname) + 1);
+                    if (mr.subvariables[j] == NULL) {
+                        continue;
+                    }
+                    strcpy(mr.subvariables[j], info->longname);
+                }
+            }
+        }
+    }
+    if (var_dict)
+        ck_hash_table_free(var_dict);
 
     if ((retval = sav_handle_fweight(ctx)) != READSTAT_OK)
         goto cleanup;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -244,9 +244,7 @@ static readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
         goto cleanup;
     }
 
-    // Allocate memory for label
-    result->label = malloc(count + 1);  // +1 for the null-terminator
-    if (result->label == NULL) {
+    if ((result->label = malloc(count + 1)) == NULL) {
         retval = READSTAT_ERROR_MALLOC;
         goto cleanup;
     }

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -926,6 +926,10 @@ static readstat_error_t sav_process_row(unsigned char *buffer, size_t buffer_len
             }
             if (++offset == col_info->width) {
                 if (++segment_offset < var_info->n_segments) {
+                    if (raw_str_used == 0) {
+                        retval = READSTAT_ERROR_PARSE;
+                        goto done;
+                    }
                     raw_str_used--;
                 }
                 offset = 0;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1,7 +1,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <math.h>
@@ -29,10 +28,6 @@
 
 #define DATA_BUFFER_SIZE    65536
 #define VERY_LONG_STRING_MAX_LENGTH INT_MAX
-
-// #ifdef _WIN32
-// #define strtok_r(s,d,p) strtok_s(s,d,p)
-// #endif
 
 /* Others defined in table below */
 
@@ -172,23 +167,7 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
         goto cleanup;
     }
 
-    // char *saveptr;
-    // char *token = strtok_r(mr_string, "$\n", &saveptr);
-    char *token = strtok(mr_string, "$\n");
-
-    int num_lines = 0;
-    while (token != NULL) {
-        if ((ctx->mr_sets = readstat_realloc(ctx->mr_sets, (num_lines + 1) * sizeof(mr_set_t))) == NULL) {
-            retval = READSTAT_ERROR_MALLOC;
-            goto cleanup;
-        }
-        retval = parse_mr_line(token, &ctx->mr_sets[num_lines]);
-        if (retval != READSTAT_OK) goto cleanup;
-        num_lines++;
-        // token = strtok_r(NULL, "$\n", &saveptr);
-        token = strtok(NULL, "$\n");
-    }
-    ctx->multiple_response_sets_length = num_lines;
+    retval = parse_mr_string(mr_string, &ctx->mr_sets, &ctx->multiple_response_sets_length);
 
 cleanup:
     free(mr_string);

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -293,11 +293,11 @@ static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx
     readstat_error_t retval = READSTAT_OK;
 
     char *mr_string = readstat_malloc(data_len + 1);
-    mr_string[data_len] = '\0';
     if (mr_string == NULL) {
         retval = READSTAT_ERROR_MALLOC;
         goto cleanup;
     }
+    mr_string[data_len] = '\0';
 
     if (ctx->io->read(mr_string, data_len, ctx->io->io_ctx) < data_len) {
         retval = READSTAT_ERROR_PARSE;

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -8,6 +8,7 @@
 #include <float.h>
 #include <time.h>
 #include <limits.h>
+#include <ctype.h>
 
 #include "../readstat.h"
 #include "../readstat_bits.h"

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1703,8 +1703,8 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
         metadata.file_label = ctx->file_label;
 
         // Replace short MR names with long names
-        ck_hash_table_t *var_dict = ck_hash_table_init(1024, 8);
-        for (size_t i = 0; i < ctx->var_count; i++) {
+        ck_hash_table_t *var_dict = ck_hash_table_init(ctx->var_index, 8);
+        for (size_t i = 0; i < ctx->var_index; i++) {
             spss_varinfo_t *current_varinfo = ctx->varinfo[i];
             if (current_varinfo != NULL && current_varinfo->name[0] != '\0') {
                 ck_str_hash_insert(current_varinfo->name, current_varinfo, var_dict);

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -1851,6 +1851,11 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
             mr_set_t mr = ctx->mr_sets[i];
             for (size_t j = 0; j < mr.num_subvars; j++) {
                 char* sv_name_upper = malloc(strlen(mr.subvariables[j]) + 1);
+                if (sv_name_upper == NULL) {
+                    retval = READSTAT_ERROR_MALLOC;
+                    goto cleanup;
+                }
+                sv_name_upper[strlen(mr.subvariables[j])] = '\0';
                 for (int c = 0; mr.subvariables[j][c] != '\0'; c++) {
                     sv_name_upper[c] = toupper((unsigned char) mr.subvariables[j][c]);
                 }

--- a/src/spss/readstat_sav_read.c
+++ b/src/spss/readstat_sav_read.c
@@ -317,7 +317,6 @@ cleanup:
 }
 
 static readstat_error_t sav_read_multiple_response_sets(size_t data_len, sav_ctx_t *ctx) {
-    return READSTAT_OK; // hatchet
     readstat_error_t retval = READSTAT_OK;
 
     char *mr_string = readstat_malloc(data_len + 1);


### PR DESCRIPTION
This PR adds functionality for reading multiple response metadata from sav files. It's been tested on a simple file that we use for PoC in Crunch.io. It's a work in progress, I'm available for any updates and changes that need to be done to it.

UPDATE: Running this function with a test file succeeds a small portion of the tires. However it throws segfaults on most tries, I can't really track it down, so any guidance on that more than welcome as well.

Here's the example on how I tried testing it:

```
include <stdlib.h>
#include "readstat.h"

typedef struct
{
    const mr_set_t *sets;
    int count;
} mr_sets_context_t;

int handle_metadata(readstat_metadata_t *metadata, void *ctx)
{
    mr_sets_context_t *mr_ctx = (mr_sets_context_t *)ctx; // Cast to non-const
    mr_ctx->count = readstat_get_multiple_response_sets_length(metadata);
    mr_ctx->sets = readstat_get_mr_sets(metadata);
    return READSTAT_HANDLER_OK;
}

int main(int argc, char *argv[])
{
    if (argc != 2)
    {
        printf("Usage: %s <filename>\n", argv[0]);
        return 1;
    }
    readstat_error_t error = READSTAT_OK;
    readstat_parser_t *parser = readstat_parser_init();
    readstat_set_metadata_handler(parser, &handle_metadata);

    // Processing
    mr_sets_context_t *mr_ctx = malloc(sizeof(mr_sets_context_t));
    error = readstat_parse_sav(parser, argv[1], mr_ctx);
    printf("Found %d records\n", mr_ctx->count);
    for (int i = 0; i < mr_ctx->count; i++)
    {
        printf("MR set %d name: %s\n", i + 1, mr_ctx->sets[i].name);
        printf("type: %c\n", mr_ctx->sets[i].type);
        printf("is dichotomy: %d\n", mr_ctx->sets[i].is_dichotomy);
    }

    // Cleanup
    readstat_parser_free(parser);
    if (error != READSTAT_OK)
    {
        printf("Error processing %s: %d\n", argv[1], error);
        return 1;
    }
    return 0;
}
```

And here's the example file:
[simple_alltypes.sav.zip](https://github.com/WizardMac/ReadStat/files/15199525/simple_alltypes.sav.zip)

This is the output from when it succeeds:
```
➜  ReadStat git:(ISS-229-add-mr-metadata-support-for-sav) ✗ DYLD_LIBRARY_PATH=./.libs ./read_mr_metadata ./simple_alltypes.sav
count: 0
label: 

Final counted value is: 1
count: 24
label: My multiple response set
Found 2 records
MR set 1 name: categorical_array
type: C
is dichotomy: 0
MR set 2 name: mymrset
type: D
is dichotomy: 1
```
and this one is when it fails (which happens more often):
```
➜  ReadStat git:(ISS-229-add-mr-metadata-support-for-sav) ✗ DYLD_LIBRARY_PATH=./.libs ./read_mr_metadata ./simple_alltypes.sav
count: 0
label: 

Final counted value is: 1
count: 24
label: My multiple response set
[1]    86961 segmentation fault  DYLD_LIBRARY_PATH=./.libs ./read_mr_metadata ./simple_alltypes.sav
```