### PR TITLE
Update test/test_buffer.h

### DIFF
--- a/src/test/test_buffer.c
+++ b/src/test/test_buffer.c
@@ -2,7 +2,7 @@
 
 #include "test_buffer.h"
 
-rt_buffer_t *buffer_init() {
+rt_buffer_t *buffer_init(void) {
     rt_buffer_t *buffer = calloc(1, sizeof(rt_buffer_t));
     buffer->size = 1024;
     buffer->bytes = malloc(buffer->size);

--- a/src/test/test_buffer.h
+++ b/src/test/test_buffer.h
@@ -10,7 +10,7 @@ typedef struct rt_buffer_ctx_s {
     size_t       pos;
 } rt_buffer_ctx_t;
 
-rt_buffer_t *buffer_init();
+rt_buffer_t *buffer_init(void);
 void buffer_reset(rt_buffer_t *buffer);
 void buffer_grow(rt_buffer_t *buffer, size_t len);
 void buffer_free(rt_buffer_t *buffer);


### PR DESCRIPTION
This fixes a compile error on clang-18:

```
In file included from src/fuzz/generate_corpus.c:13: src/fuzz/../test/test_buffer.h:13:25: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
   13 | rt_buffer_t *buffer_init();
      |                         ^
      |                          void
1 error generated.