### PR TITLE
Set variable formats for STATA when specified

### DIFF
--- a/src/bin/write/mod_readstat.c
+++ b/src/bin/write/mod_readstat.c
@@ -166,6 +166,7 @@ static int handle_variable(int index, readstat_variable_t *variable,
     readstat_type_t type = readstat_variable_get_type(variable);
     const char *name = readstat_variable_get_name(variable);
     const char *label = readstat_variable_get_label(variable);
+    const char *format = readstat_variable_get_format(variable);
     size_t storage_width = readstat_variable_get_storage_width(variable);
     int display_width = readstat_variable_get_display_width(variable);
     int missing_ranges_count = readstat_variable_get_missing_ranges_count(variable);
@@ -180,6 +181,8 @@ static int handle_variable(int index, readstat_variable_t *variable,
         readstat_variable_set_label_set(new_variable, label_set);
         if (mod_ctx->is_sas7bdat) {
             readstat_variable_set_format(new_variable, val_labels);
+        } else if (mod_ctx->is_dta) {
+            readstat_variable_set_format(new_variable, format);
         }
     }
 


### PR DESCRIPTION
When converting data from CSV with a JSON metadata file to STATA, the variable formats were being dropped. This caused STATA not to display the variables correctly, as described in #312, to wit:

```
. use "stata_repro"
((null))

. describe

Contains data from stata_repro.dta
 Observations:             2                  (null)
    Variables:             3                  24 Oct 2024 15:08
-----------------------------------------------------------------------
Variable      Storage   Display    Value
    name         type    format    label      Variable label
-----------------------------------------------------------------------
permno          double  %10.0g                CRSP permno (permno)
date            long    %12.0g                Day of last price observation (date)
eom             long    %12.0g                End of month (eom)
-----------------------------------------------------------------------
```
The `date` and `eom` fields should be of type `"DATE"` (and `permno` should be `"UNSPECIFIED"`), as specified in the .json file.

With this change, STATA now recognizes the data display format, eg:
```
. use "output"
((null))

. describe

Contains data from output.dta
 Observations:             2                  (null)
    Variables:             3                  28 Oct 2024 12:41
-----------------------------------------------------------------------
Variable      Storage   Display    Value
    name         type    format    label      Variable label
-----------------------------------------------------------------------
permno          double  %9.0f                 CRSP permno (permno)
date            long    %td                   Day of last price observation (date)
eom             long    %td                   End of month (eom)
-----------------------------------------------------------------------
Sorted by:

. list

     +--------------------------------+
     | permno        date         eom |
     |--------------------------------|
1. |  10107   31jan2020   31jan2020 |
2. |  10107   28feb2020   29feb2020 |
     +--------------------------------+
```