### PR TITLE
Add Support for DATE_TIMEs in STATA

### DIFF
--- a/src/bin/extract_metadata.c
+++ b/src/bin/extract_metadata.c
@@ -155,15 +155,15 @@ static int handle_variable_sav(int index, readstat_variable_t *variable, const c
             } else if (hasPrefix(vformat, "YMDHMS16") == 0) {
                 // e.g. 2013-01-31 1:02
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy-MM-dd h:mm";
+                pattern = "yyyy-MM-dd hh:mm";
             } else if (hasPrefix(vformat, "YMDHMS19") == 0) {
                 // e.g. 2013-01-31 1:02:33
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy-MM-dd h:mm:ss";
+                pattern = "yyyy-MM-dd hh:mm:ss";
             } else if (hasPrefix(vformat, "YMDHMS19.2") == 0) {
                 // e.g. 2013-01-31 1:02:33.72
                 format = EXTRACT_METADATA_FORMAT_DATE_TIME;
-                pattern = "yyyy-MM-dd h:mm:ss.SS+";
+                pattern = "yyyy-MM-dd hh:mm:ss.SS+";
             } else if (hasPrefix(vformat, "MTIME5") == 0) {
                 // e.g. 1754:36
                 format = EXTRACT_METADATA_FORMAT_TIME;

--- a/src/bin/read_csv/csv_metadata.h
+++ b/src/bin/read_csv/csv_metadata.h
@@ -12,6 +12,7 @@ typedef struct csv_metadata {
     void *user_ctx;
     readstat_variable_t *variables;
     int* is_date;
+    int* is_date_time;
     struct json_metadata *json_md;
     rs_read_module_t *output_module;
 } csv_metadata;

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -193,7 +193,6 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
     extract_metadata_type_t coltype = column_type(c->json_md, column, c->output_format);
     if (coltype == EXTRACT_METADATA_TYPE_NUMERIC) {
         extract_metadata_format_t colformat = column_format(c->json_md, column);
-
         switch (colformat) {
         case EXTRACT_METADATA_FORMAT_NUMBER:
         case EXTRACT_METADATA_FORMAT_PERCENT:
@@ -387,39 +386,98 @@ static readstat_value_t value_double_dta(const char *s, size_t len, struct csv_m
 }
 
 static readstat_value_t value_double_date_time_dta(const char *s, size_t len, struct csv_metadata *c) {
-    char *dest;
-    readstat_variable_t *var = &c->variables[c->columns];
-    double val = strtod(s, &dest);
-    if (dest == s) {
-        fprintf(stderr, "not a number: %s\n", (char*)s);
+    // Handle empty or NULL strings as missing values
+    if (s == NULL || len == 0 || *s == '\0') {
+        readstat_value_t value = {
+            .type = READSTAT_TYPE_DOUBLE,
+            .is_system_missing = 1,
+            .v = { .double_value = NAN }
+        };
+        return value;
+    }
+
+    // Truncate the date string to 23 characters to remove the timezone offset and
+    // microseconds, if present. STATA does not support timezones or microseconds.
+    char date_time[24];
+    strncpy(date_time, s, 23);
+    date_time[23] = '\0';
+
+    // Parse date-time components
+    int year, month, day, hour, minute, second, msecs = 0;
+    int matched = sscanf(
+        date_time,
+        "%d-%d-%d %d:%d:%d.%d",
+        &year, &month, &day, &hour, &minute, &second, &msecs
+    );
+    if (matched < 6 || matched > 8) {
+        fprintf(stderr, "%s:%d not a valid date-time: %s (expected format: yyyy-mm-dd hh:MM:SS with optional milliseconds. Datetime string is truncated at 23 characters to ignore microseconds and timezone information.)\n", __FILE__, __LINE__, date_time);
         exit(EXIT_FAILURE);
     }
-    int missing_ranges_count = readstat_variable_get_missing_ranges_count(var);
-    for (int i=0; i<missing_ranges_count; i++) {
-        readstat_value_t lo_val = readstat_variable_get_missing_range_lo(var, i);
-        readstat_value_t hi_val = readstat_variable_get_missing_range_hi(var, i);
-        if (readstat_value_type(lo_val) != READSTAT_TYPE_DOUBLE) {
-            fprintf(stderr, "%s:%d expected type of lo_val to be of type double. Should not happen\n", __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        double lo = readstat_double_value(lo_val);
-        double hi = readstat_double_value(hi_val);
-        if (val >= lo && val <= hi) {
-            readstat_value_t value = {
-                .type = READSTAT_TYPE_DOUBLE,
-                .is_tagged_missing = 1,
-                .tag = 'a' + i,
-                .v = { .double_value = val }
-                };
-            return value;
-        }
+
+    // Get days since the epoch for the date
+    char days_since_epoch_string[11];
+    sprintf(days_since_epoch_string, "%04d-%02d-%02d", year, month, day);
+    char* dest;
+    int days_since_epoch = readstat_dta_num_days(days_since_epoch_string, &dest);
+
+    // Add the hours, minutes, and seconds to the days
+    double msecs_since_epoch = 86400000.0 * days_since_epoch + hour * 3600000.0 + minute * 60000.0 + second * 1000.0 + msecs * 1.0;
+
+    // Adjust for leap seconds; 27 have occurred as of writing this code
+    // https://en.m.wikipedia.org/wiki/Leap_second
+    typedef struct {
+        int year;
+        int month;
+        int day;
+    } leap_second_date;
+    
+    leap_second_date leap_seconds[] = {
+        {1972, 6, 30}, {1972, 12, 31},  // +2 seconds in 1972
+        {1973, 12, 31},                 // +1 second in 1973
+        {1974, 12, 31},                 // +1 second in 1974
+        {1975, 12, 31},                 // +1 second in 1975
+        {1976, 12, 31},                 // +1 second in 1976
+        {1977, 12, 31},                 // +1 second in 1977
+        {1978, 12, 31},                 // +1 second in 1978
+        {1979, 12, 31},                 // +1 second in 1979
+        {1981, 6, 30},                  // +1 second in 1981
+        {1982, 6, 30},                  // +1 second in 1982
+        {1983, 6, 30},                  // +1 second in 1983
+        {1985, 6, 30},                  // +1 second in 1985
+        {1987, 12, 31},                 // +1 second in 1987
+        {1989, 12, 31},                 // +1 second in 1989
+        {1990, 12, 31},                 // +1 second in 1990
+        {1992, 6, 30},                  // +1 second in 1992
+        {1993, 6, 30},                  // +1 second in 1993
+        {1994, 6, 30},                  // +1 second in 1994
+        {1995, 12, 31},                 // +1 second in 1995
+        {1997, 6, 30},                  // +1 second in 1997
+        {1998, 12, 31},                 // +1 second in 1998
+        {2005, 12, 31},                 // +1 second in 2005
+        {2008, 12, 31},                 // +1 second in 2008
+        {2012, 6, 30},                  // +1 second in 2012
+        {2015, 6, 30},                  // +1 second in 2015
+        {2016, 12, 31}                  // +1 second in 2016
+    };
+
+    int leap_second_count = sizeof(leap_seconds) / sizeof(leap_seconds[0]);
+    int leap_seconds_to_add = 0;
+
+    for (int i = 0; i < leap_second_count; i++) {
+        // If the date is after this leap second, add one second
+        if (
+            (year > leap_seconds[i].year) ||
+            (year == leap_seconds[i].year && month > leap_seconds[i].month) ||
+            (year == leap_seconds[i].year && month == leap_seconds[i].month && day > leap_seconds[i].day)
+        ) { leap_seconds_to_add++; }
     }
+    msecs_since_epoch += leap_seconds_to_add * 1000.0;
 
     readstat_value_t value = {
         .type = READSTAT_TYPE_DOUBLE,
-        .is_tagged_missing = 0,
-        .v = { .double_value = val }
+        .v = { .double_value = msecs_since_epoch }
     };
+
     return value;
 }
 
@@ -436,7 +494,6 @@ void produce_csv_value_dta(void *csv_metadata, const char *s, size_t len) {
     } else if (is_date) {
         value = value_int32_date_dta(s, len, c);
     } else if (is_date_time) {
-        printf("WE ARE IN is_date_time, YAY!!!");
         value = value_double_date_time_dta(s, len, c);
     } else if (var->type == READSTAT_TYPE_DOUBLE) {
         value = value_double_dta(s, len, c);

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -399,8 +399,7 @@ static readstat_value_t value_double_date_time_dta(const char *s, size_t len, st
     // Truncate the date string to 23 characters to remove the timezone offset and
     // microseconds, if present. STATA does not support timezones or microseconds.
     char date_time[24];
-    strncpy(date_time, s, 23);
-    date_time[23] = '\0';
+    snprintf(date_time, sizeof(date_time), "%s", s);
 
     // Parse date-time components
     int year, month, day, hour, minute, second, msecs = 0;
@@ -416,7 +415,7 @@ static readstat_value_t value_double_date_time_dta(const char *s, size_t len, st
 
     // Get days since the epoch for the date
     char days_since_epoch_string[11];
-    sprintf(days_since_epoch_string, "%04d-%02d-%02d", year, month, day);
+    snprintf(days_since_epoch_string, sizeof(days_since_epoch_string), "%04d-%02d-%02d", year, month, day);
     char* dest;
     int days_since_epoch = readstat_dta_num_days(days_since_epoch_string, &dest);
 

--- a/src/bin/read_csv/mod_dta.c
+++ b/src/bin/read_csv/mod_dta.c
@@ -193,6 +193,7 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
     extract_metadata_type_t coltype = column_type(c->json_md, column, c->output_format);
     if (coltype == EXTRACT_METADATA_TYPE_NUMERIC) {
         extract_metadata_format_t colformat = column_format(c->json_md, column);
+
         switch (colformat) {
         case EXTRACT_METADATA_FORMAT_NUMBER:
         case EXTRACT_METADATA_FORMAT_PERCENT:
@@ -206,7 +207,7 @@ void produce_column_header_dta(void *csv_metadata, const char *column, readstat_
         break;
         case EXTRACT_METADATA_FORMAT_TIME:
         case EXTRACT_METADATA_FORMAT_DATE_TIME:
-            var->type = READSTAT_TYPE_INT32;
+            var->type = READSTAT_TYPE_DOUBLE;
             snprintf(var->format, sizeof(var->format), "%s", "%tC");
             // %tC => is equivalent to coordinated universal time (UTC)
         break;
@@ -385,10 +386,48 @@ static readstat_value_t value_double_dta(const char *s, size_t len, struct csv_m
     return value;
 }
 
+static readstat_value_t value_double_date_time_dta(const char *s, size_t len, struct csv_metadata *c) {
+    char *dest;
+    readstat_variable_t *var = &c->variables[c->columns];
+    double val = strtod(s, &dest);
+    if (dest == s) {
+        fprintf(stderr, "not a number: %s\n", (char*)s);
+        exit(EXIT_FAILURE);
+    }
+    int missing_ranges_count = readstat_variable_get_missing_ranges_count(var);
+    for (int i=0; i<missing_ranges_count; i++) {
+        readstat_value_t lo_val = readstat_variable_get_missing_range_lo(var, i);
+        readstat_value_t hi_val = readstat_variable_get_missing_range_hi(var, i);
+        if (readstat_value_type(lo_val) != READSTAT_TYPE_DOUBLE) {
+            fprintf(stderr, "%s:%d expected type of lo_val to be of type double. Should not happen\n", __FILE__, __LINE__);
+            exit(EXIT_FAILURE);
+        }
+        double lo = readstat_double_value(lo_val);
+        double hi = readstat_double_value(hi_val);
+        if (val >= lo && val <= hi) {
+            readstat_value_t value = {
+                .type = READSTAT_TYPE_DOUBLE,
+                .is_tagged_missing = 1,
+                .tag = 'a' + i,
+                .v = { .double_value = val }
+                };
+            return value;
+        }
+    }
+
+    readstat_value_t value = {
+        .type = READSTAT_TYPE_DOUBLE,
+        .is_tagged_missing = 0,
+        .v = { .double_value = val }
+    };
+    return value;
+}
+
 void produce_csv_value_dta(void *csv_metadata, const char *s, size_t len) {
     struct csv_metadata *c = (struct csv_metadata *)csv_metadata;
     readstat_variable_t *var = &c->variables[c->columns];
     int is_date = c->is_date[c->columns];
+    int is_date_time = c->is_date_time[c->columns];
     int obs_index = c->rows - 1; // TODO: ???
     readstat_value_t value;
 
@@ -396,6 +435,9 @@ void produce_csv_value_dta(void *csv_metadata, const char *s, size_t len) {
         value = value_sysmiss(s, len, c);
     } else if (is_date) {
         value = value_int32_date_dta(s, len, c);
+    } else if (is_date_time) {
+        printf("WE ARE IN is_date_time, YAY!!!");
+        value = value_double_date_time_dta(s, len, c);
     } else if (var->type == READSTAT_TYPE_DOUBLE) {
         value = value_double_dta(s, len, c);
     } else if (var->type == READSTAT_TYPE_STRING) {

--- a/src/bin/read_csv/read_csv.c
+++ b/src/bin/read_csv/read_csv.c
@@ -46,6 +46,7 @@ static void produce_column_header(struct csv_metadata *c, void *s, size_t len) {
 
     extract_metadata_format_t colformat = column_format(c->json_md, column);
     c->is_date[c->columns] = colformat == EXTRACT_METADATA_FORMAT_DATE;
+    c->is_date_time[c->columns] = colformat == EXTRACT_METADATA_FORMAT_DATE_TIME;
     if (c->output_module->header) {
         c->output_module->header(c, column, var);
     }

--- a/src/bin/read_csv/read_csv.c
+++ b/src/bin/read_csv/read_csv.c
@@ -76,6 +76,7 @@ static void csv_metadata_cell(void *s, size_t len, void *data)
     if (c->rows == 0) {
         c->variables = realloc(c->variables, (c->columns+1) * sizeof(readstat_variable_t));
         c->is_date = realloc(c->is_date, (c->columns+1) * sizeof(int));
+        c->is_date_time = realloc(c->is_date_time, (c->columns+1) * sizeof(int));
         produce_column_header(c, s, len);
     } else if (c->rows >= 1 && c->handle.value && c->output_module->csv_value) {
         c->output_module->csv_value(c, s, len);
@@ -184,6 +185,10 @@ cleanup:
     if (md->is_date) {
         free(md->is_date);
         md->is_date = NULL;
+    }
+    if (md->is_date_time) {
+        free(md->is_date_time);
+        md->is_date_time = NULL;
     }
     csv_free(p);
     io->close(io->io_ctx);


### PR DESCRIPTION
When converting a CSV to STATA, I received the following error: `src/bin/read_csv/mod_dta.c:404 unsupported variable type 3`

This PR adds support for DATE_TIMEs to the STATA writer. Here's the test CSV that was used:

```csv
orgpermid,valuecalcdt,justdate
4295533401,2025-03-01 00:00:00,2024-03-01
4295533401,2023-08-26 00:00:00,2024-08-26
4295533401,1974-02-08 00:00:00,2024-02-08
4295533401,1972-06-29 23:59:59.123456+05,2024-02-21
4295533401,1854-03-01 00:00:00,2024-01-01
4295533401,1974-02-08 11:38:23.543212-02,2024-02-08
4295533401,,2024-02-21
4295533401,1972-06-29 23:59:59,2024-02-21
4295533401,1854-03-01 10:42:42,2024-01-01
```

Here's the JSON mapping file:

```json
{
    "type": "STATA",
    "variables": [
        {
            "type": "NUMERIC",
            "name": "orgpermid",
            "label": "OrgPermID (orgpermid)",
            "format": "UNSPECIFIED"
        },
        {
            "type": "NUMERIC",
            "name": "valuecalcdt",
            "label": "ValueCalcDt (valuecalcdt)",
            "format": "DATE_TIME"
        },
        {
            "type": "NUMERIC",
            "name": "justdate",
            "label": "JustDate (justdate)",
            "format": "DATE"
        }
    ]
}
```

...and the output in STATA from the written file:

```
. list

     +-------------------------------------------+
     | orgper~d          valuecalcdt    justdate |
     |-------------------------------------------|
  1. | 4.30e+09   01mar2025 00:00:00   01mar2024 |
  2. | 4.30e+09   26aug2023 00:00:00   26aug2024 |
  3. | 4.30e+09   08feb1974 00:00:00   08feb2024 |
  4. | 4.30e+09   29jun1972 23:59:59   21feb2024 |
  5. | 4.30e+09   01mar1854 00:00:00   01jan2024 |
     |-------------------------------------------|
  6. | 4.30e+09   08feb1974 11:38:23   08feb2024 |
  7. | 4.30e+09                    .   21feb2024 |
  8. | 4.30e+09   29jun1972 23:59:59   21feb2024 |
  9. | 4.30e+09   01mar1854 10:42:42   01jan2024 |
     +-------------------------------------------
```

...and to validate millisecond display:

```
. format valuecalcdt %tCHH:MM:SS.sss

. list

     +-------------------------------------+
     | orgper~d    valuecalcdt    justdate |
     |-------------------------------------|
  1. | 4.30e+09   00:00:00.000   01mar2024 |
  2. | 4.30e+09   00:00:00.000   26aug2024 |
  3. | 4.30e+09   00:00:00.000   08feb2024 |
  4. | 4.30e+09   23:59:59.123   21feb2024 |
  5. | 4.30e+09   00:00:00.000   01jan2024 |
     |-------------------------------------|
  6. | 4.30e+09   11:38:23.543   08feb2024 |
  7. | 4.30e+09              .   21feb2024 |
  8. | 4.30e+09   23:59:59.000   21feb2024 |
  9. | 4.30e+09   10:42:42.000   01jan2024 |
     +-------------------------------------+
```

In reviewing the code, I also noticed the patterns for the three DATE_TIME patterns did not match the `Date-Time Unit` from the source spec here: https://libguides.library.kent.edu/SPSS/DatesTime

I've also changed those patterns to match the spec.