### PR TITLE
Add DuckDB `read_stat` community extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Language Bindings
 * Perl 6: [ReadStat.pm6](https://github.com/WizardMac/ReadStat.pm6)
 * Python: [pyreadstat](https://github.com/Roche/pyreadstat)
 * R: [haven](https://github.com/tidyverse/haven)
+* DuckDB: [`read_stat`](<https://github.com/mettekou/duckdb-read-stat>)
 
 
 Docker


### PR DESCRIPTION
@evanmiller Thank you for your amazing work on ReadStat! I have created a DuckDB community extension based on it, could you add it to the readme file for this repository? I know DuckDB isn't quite a language, but I added it to the language bindings section anyway. Feel free to propose an alternative.