### PR TITLE
[#ISS-329]: Be able to figure out dot (`.`) in MR var name

### DIFF
--- a/src/spss/readstat_sav_parse_mr_name.c
+++ b/src/spss/readstat_sav_parse_mr_name.c
@@ -14,23 +14,24 @@ static const char _mr_extractor_actions[] = {
 };
 
 static const char _mr_extractor_key_offsets[] = {
-	0, 0, 7, 15, 17, 20, 22, 25, 
-	33, 44
+	0, 0, 8, 17, 19, 22, 24, 27, 
+	36, 48
 };
 
 static const char _mr_extractor_trans_keys[] = {
-	95, 48, 57, 65, 90, 97, 122, 61, 
-	95, 48, 57, 65, 90, 97, 122, 67, 
-	68, 32, 48, 57, 48, 57, 32, 48, 
-	57, 32, 95, 48, 57, 65, 90, 97, 
-	122, 0, 32, 95, 9, 13, 48, 57, 
-	65, 90, 97, 122, 95, 48, 57, 65, 
-	90, 97, 122, 0
+	46, 95, 48, 57, 65, 90, 97, 122, 
+	46, 61, 95, 48, 57, 65, 90, 97, 
+	122, 67, 68, 32, 48, 57, 48, 57, 
+	32, 48, 57, 32, 46, 95, 48, 57, 
+	65, 90, 97, 122, 0, 32, 46, 95, 
+	9, 13, 48, 57, 65, 90, 97, 122, 
+	46, 95, 48, 57, 65, 90, 97, 122, 
+	0
 };
 
 static const char _mr_extractor_single_lengths[] = {
-	0, 1, 2, 0, 1, 0, 1, 2, 
-	3, 1
+	0, 2, 3, 0, 1, 0, 1, 3, 
+	4, 2
 };
 
 static const char _mr_extractor_range_lengths[] = {
@@ -39,17 +40,17 @@ static const char _mr_extractor_range_lengths[] = {
 };
 
 static const char _mr_extractor_index_offsets[] = {
-	0, 0, 5, 11, 13, 16, 18, 21, 
-	27, 35
+	0, 0, 6, 13, 15, 18, 20, 23, 
+	30, 39
 };
 
 static const char _mr_extractor_indicies[] = {
-	0, 0, 0, 0, 1, 2, 0, 0, 
-	0, 0, 1, 3, 1, 4, 5, 1, 
-	6, 1, 7, 6, 1, 8, 9, 9, 
-	9, 9, 1, 10, 10, 9, 10, 9, 
-	9, 9, 1, 9, 9, 9, 9, 1, 
-	0
+	0, 0, 0, 0, 0, 1, 0, 2, 
+	0, 0, 0, 0, 1, 3, 1, 4, 
+	5, 1, 6, 1, 7, 6, 1, 8, 
+	9, 9, 9, 9, 9, 1, 10, 10, 
+	9, 9, 10, 9, 9, 9, 1, 9, 
+	9, 9, 9, 9, 1, 0
 };
 
 static const char _mr_extractor_trans_targs[] = {
@@ -89,14 +90,14 @@ readstat_error_t extract_mr_data(const char *line, mr_set_t *result) {
 
     // Execute Ragel finite state machine (FSM)
     
-#line 93 "src/spss/readstat_sav_parse_mr_name.c"
+#line 94 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_extractor_start;
 	}
 
 #line 96 "src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 100 "src/spss/readstat_sav_parse_mr_name.c"
+#line 101 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -233,7 +234,7 @@ _match:
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 	break;
-#line 237 "src/spss/readstat_sav_parse_mr_name.c"
+#line 238 "src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 
@@ -288,7 +289,7 @@ readstat_error_t parse_mr_line(const char *line, mr_set_t *result) {
 }
 
 
-#line 292 "src/spss/readstat_sav_parse_mr_name.c"
+#line 293 "src/spss/readstat_sav_parse_mr_name.c"
 static const char _mr_parser_actions[] = {
 	0, 1, 0
 };
@@ -344,14 +345,14 @@ readstat_error_t parse_mr_string(const char *line, mr_set_t **mr_sets, size_t *n
     *n_mr_lines = 0;
 
     
-#line 348 "src/spss/readstat_sav_parse_mr_name.c"
+#line 349 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	cs = mr_parser_start;
 	}
 
 #line 172 "src/spss/readstat_sav_parse_mr_name.rl"
     
-#line 355 "src/spss/readstat_sav_parse_mr_name.c"
+#line 356 "src/spss/readstat_sav_parse_mr_name.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -441,7 +442,7 @@ _match:
         start = p + 1;
     }
 	break;
-#line 445 "src/spss/readstat_sav_parse_mr_name.c"
+#line 446 "src/spss/readstat_sav_parse_mr_name.c"
 		}
 	}
 

--- a/src/spss/readstat_sav_parse_mr_name.rl
+++ b/src/spss/readstat_sav_parse_mr_name.rl
@@ -60,7 +60,7 @@
         mr_subvariables[mr_subvar_count++] = subvar;
     }
 
-    nc = (alnum | '_'); # name character
+    nc = (alnum | '_' | '.'); # name character (including dots)
     name = nc+ '=' > extract_mr_name;
     type = ('C' | 'D'){1} > extract_mr_type;
     counted_value = digit* ' ' > extract_counted_value;


### PR DESCRIPTION
ReadStat fails to parse valid multiple response set strings when the set name contains a dot.

**Failing MR string:**
```
Q1.4=D1 1 12 MR set label q1_4_1 q1_4_2 q1_4_3 q1_4_4 q1_4_5 q1_4_6 q1_4_7 q1_4_8 q1_4_9
```

This is valid per SPSS and PSPP. IBM SPSS opens the file without issue.

**Spec reference:**  
https://www.gnu.org/software/pspp/pspp-dev/html_node/Multiple-Response-Sets-Records.html

Parser likely misinterprets the `.` in the set name as invalid or as a delimiter.

**Expected behavior:**  
Names with dots (e.g., `Q1.4`) should be accepted and parsed correctly.