### PR TITLE
Fix XPT writing for LABELV8/9 headers

### DIFF
--- a/src/sas/readstat_xport_write.c
+++ b/src/sas/readstat_xport_write.c
@@ -49,12 +49,21 @@ cleanup:
     return retval;
 }
 
-static readstat_error_t xport_write_header_record_v8(readstat_writer_t *writer, 
+static readstat_error_t xport_write_header_record_obsv8(readstat_writer_t *writer, 
+        int row_count) {
+    char record[RECORD_LEN+1];
+    snprintf(record, sizeof(record),
+            "HEADER RECORD*******OBSV8   HEADER RECORD!!!!!!!" "%15d",
+            row_count);
+    return xport_write_record(writer, record);
+}
+
+static readstat_error_t xport_write_header_record_labelv8(readstat_writer_t *writer, 
         xport_header_record_t *xrecord) {
     char record[RECORD_LEN+1];
     snprintf(record, sizeof(record),
-            "HEADER RECORD*******%-8sHEADER RECORD!!!!!!!" "%15d" "%15d",
-            xrecord->name, xrecord->num1, xrecord->num2);
+            "HEADER RECORD*******%-8sHEADER RECORD!!!!!!!" "%-5d",
+            xrecord->name, xrecord->num1);
     return xport_write_record(writer, record);
 }
 
@@ -167,7 +176,7 @@ static readstat_error_t xport_write_variables(readstat_writer_t *writer) {
         if (any_has_long_format) {
             strcpy(header.name, "LABELV9");
         }
-        retval = xport_write_header_record_v8(writer, &header);
+        retval = xport_write_header_record_labelv8(writer, &header);
         if (retval != READSTAT_OK)
             goto cleanup;
 
@@ -357,11 +366,7 @@ static readstat_error_t xport_write_namestr_header_record(readstat_writer_t *wri
 
 static readstat_error_t xport_write_obs_header_record(readstat_writer_t *writer) {
     if (writer->version == 8) {
-        xport_header_record_t xrecord = {
-            .name = "OBSV8",
-            .num1 = writer->row_count
-        };
-        return xport_write_header_record_v8(writer, &xrecord);
+        return xport_write_header_record_obsv8(writer, writer->row_count);
     }
     xport_header_record_t xrecord = { 
         .name = "OBS"


### PR DESCRIPTION
This PR updates writing for OBSV8 and LABELV8/9 headers in SAS XPORT files (see tidyverse/haven#784).

LABELV8/9 headers are only used when writing variable labels longer than 40 characters and includes the number of variables with long labels in the header, but this number is left aligned instead of right aligned.

The OBSV8 headers were working fine but I cleaned up the function a little while I was at it since the label and obs headers are now using their own functions for V8 files instead of sharing a header writing function due to the differing alignment.

Have tested with SAS and all looks to be working fine.