### PR TITLE
Allow 0 width columns in sas7bdat reader

### DIFF
--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -667,7 +667,7 @@ static readstat_error_t sas7bdat_validate_column(col_info_t *col_info) {
         }
     }
     if (col_info->type == READSTAT_TYPE_STRING) {
-        if (col_info->width > INT16_MAX || col_info->width == 0) {
+        if (col_info->width > INT16_MAX) {
             return READSTAT_ERROR_PARSE;
         }
     }


### PR DESCRIPTION
This PR fixes an error when reading SAS files with zero observations (see tidyverse/haven#627). When there are zero observations SAS appears to write string variables with a default width of 0, which was throwing an error in `sas7bdat_validate_column()`.

I've removed the check for width == 0 since this is allowed by SAS and the zero observation data file loads successfully so this check seems unnecessary.