### PR TITLE
Validate XPort v5 variable name length (max 8 chars)

### DIFF
--- a/src/sas/readstat_xport_write.c
+++ b/src/sas/readstat_xport_write.c
@@ -537,6 +537,10 @@ static readstat_error_t xport_metadata_ok(void *writer_ctx) {
     return READSTAT_OK;
 }
 
+static readstat_error_t xport_v5_validate_variable(const readstat_variable_t *variable) {
+    return sas_validate_name(readstat_variable_get_name(variable), 8);
+}
+
 readstat_error_t readstat_begin_writing_xport(readstat_writer_t *writer, void *user_ctx, long row_count) {
 
     if (writer->version == 0)
@@ -555,7 +559,11 @@ readstat_error_t readstat_begin_writing_xport(readstat_writer_t *writer, void *u
     writer->callbacks.write_missing_tagged = &xport_write_missing_tagged;
 
     writer->callbacks.variable_width = &xport_variable_width;
-    writer->callbacks.variable_ok = &sas_validate_variable;
+    if (writer->version == 5) {
+        writer->callbacks.variable_ok = &xport_v5_validate_variable;
+    } else {
+        writer->callbacks.variable_ok = &sas_validate_variable;
+    }
 
     writer->callbacks.begin_data = &xport_begin_data;
     writer->callbacks.end_data = &xport_end_data;

--- a/src/test/test_list.h
+++ b/src/test/test_list.h
@@ -895,6 +895,17 @@ static rt_test_group_t _test_groups[] = {
                 }
             },
             {
+                .label = "XPORT v5 column name is too long",
+                .write_error = READSTAT_ERROR_NAME_IS_TOO_LONG,
+                .test_formats = RT_FORMAT_XPORT_5,
+                .columns = {
+                    {
+                        .name = "VAR123456",
+                        .type = READSTAT_TYPE_DOUBLE
+                    }
+                }
+            },
+            {
                 .label = "POR column name is too long",
                 .write_error = READSTAT_ERROR_NAME_IS_TOO_LONG,
                 .test_formats = RT_FORMAT_POR,


### PR DESCRIPTION
The XPort writer was using sas_validate_variable which allows 32-char names, but v5 XPort only supports 8-char names (nname[8]). Names longer than 8 chars were silently truncated. Now v5 returns READSTAT_ERROR_NAME_IS_TOO_LONG instead.

(Commit created with Claude Code)