### PR TITLE
Fix Windows pipeline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,20 +54,15 @@ AS_CASE([$host],
 AC_SUBST([EXTRA_WARNINGS])
 
 AS_CASE([$host],
-	[*mingw*|*cygwin*], [EXTRA_LDFLAGS="$LTLIBICONV -no-undefined"],
-	[EXTRA_LDFLAGS="$LTLIBICONV"])
+	[*mingw*|*cygwin*], [EXTRA_LDFLAGS="-liconv -no-undefined"],
+	[EXTRA_LDFLAGS=""])
 AC_SUBST([EXTRA_LDFLAGS])
 
 AS_CASE([$host],
-	[*mingw*], 
-        [
-        #There is no real way to determine whether UCRT is used vs normal MINGW but one way is by checking a define in <windows.h>
-        #If we are in UCRT we do not want to set the spawnv define because it breaks the build
-        IS_UCRT=`echo '#include <windows.h>'| gcc -E -dM -  | grep -i _UCRT | xargs`
-        AS_IF([test "$IS_UCRT" == ""], [
-            CFLAGS="$CFLAGS -D_spawnv=spawnv"
-        ])
-    ],
+	[*mingw*],
+	[
+		AC_CHECK_FUNCS([_spawnv], [], [CFLAGS="$CFLAGS -D_spawnv=spawnv"])
+	],
 	[CFLAGS="$CFLAGS"])
 
 AC_ARG_VAR([LIB_FUZZING_ENGINE], [Location of prebuilt fuzzing engine library])


### PR DESCRIPTION
This PR fixes the Windows build pipeline, which is currently failing.

### The make step

The make step is currently failing on Windows as the linker complains about unresolved references to `libiconv` functions.

The proposed fix is to replace the variable `LTLIBICONV` in `configure.ac` by hard-coded values:

- `-liconv` for the Windows build
- `''` for the other builds

The variable `LTLIBICONV` should actually be created by the macro `AM_ICONV` but this was removed in #342. And the dependency `gettext` that is needed for `AM_ICONV` was removed in #350.

This is probably not the cleanest fix but it keeps changes restricted to the Windows build.

### The make check step

When the `make` step is fixed in the Windows pipline, the `make check` currently fails as the next step.

The problem is that the compiler is missing the flag `-D_spawnv=spawnv`.

This is caused by the change from #301.

The proposed change works as expected in the pipeline. And it should also work for UCRT.