### PR TITLE
Update GitHub checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - name: Install packages
         run: sudo apt install gcc-9 gcc-10 gcc-11 gcc-12
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Install packages
         run: brew install automake libtool
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure
@@ -83,7 +83,7 @@ jobs:
             base-devel
             gcc
             libiconv-devel
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - name: Install packages
         run: sudo apt install gettext
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Autoconf
         run: autoreconf -i -f
       - name: Configure

--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,13 @@ config.log
 config.status
 config.sub
 configure
+configure~
 depcomp
 install-sh
 libreadstat.la
 libtool
 ltmain.sh
+m4/
 Makefile
 Makefile.in
 missing
@@ -31,6 +33,7 @@ test_readstat
 *.log
 *.trs
 test_csv_to_dta*
+.vs/
 .vscode/
 *.swp
 dev/


### PR DESCRIPTION
Thanks for merging #367! The build on `dev` is now green. 💚 🚀 

To keep it that way, I think the following warning from the current builds is noteworthy:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR upgrades the action from v2 to the current latest major version v6, which successfully removes the warning.

For unrelated reasons, I've amended the `.gitignore` by some entries:

- `configure~` is created by the autotools on `autoreconf`-ing an existing `configure` script
- `m4` is being created due to `AC_CONFIG_MACRO_DIRS` from #342
- `.vs` is created when using Visual Studio (without the Code)
