### PR TITLE
Upgrade GitHub action upload-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         continue-on-error: true
       - name: Upload test log
         if: steps.make-check.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-suite-log-linux-${{ matrix.compiler }}
           path: test-suite.log
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
       - name: Upload test log
         if: steps.make-check.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-suite-log-macos-${{ matrix.compiler }}
           path: test-suite.log
@@ -96,7 +96,7 @@ jobs:
         continue-on-error: true
       - name: Upload test log
         if: steps.make-check.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-suite-log-windows
           path: test-suite.log

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: artifacts


### PR DESCRIPTION
Sorry again for the noise from the failed fuzzing in #370.

The fuzzing issues in #370 are now fixed. But the preceding failures have uncovered a deprecation warning similar to the one fixed with #368:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The upgraded action is only triggered on build failures. I can push both build failures or fuzzing failures (🥹) onto this branch if you'd like to see it.