### PR TITLE
Relax version string validation for SAS 7

### DIFF
--- a/src/sas/readstat_sas.c
+++ b/src/sas/readstat_sas.c
@@ -327,7 +327,7 @@ readstat_error_t sas_read_header(readstat_io_t *io, sas_header_info_t *hinfo,
         goto cleanup;
     }
     // revision_tag is usually M, but J has been observed in the wild (not created with SAS?)
-    if (revision_tag != 'M' && revision_tag != 'J') {
+    if ((major == '8' || major == '9') && revision_tag != 'M' && revision_tag != 'J') {
         retval = READSTAT_ERROR_PARSE;
         goto cleanup;
     }


### PR DESCRIPTION
### Background

An issue has been reported in pyreadstat with a sample file: https://github.com/Roche/pyreadstat/issues/340

There are two problems:
- The file contains the SAS release string `7.00.00B`, which fails a validation in the SAS header parsing.
- The file contains soft-deleted rows.

This PR is only about the first problem. Soft-deleted rows are handled in #366.

### Proposed Change

The release string `7.00.00B` has a slightly different format than the more usual `8.0202M0` or `9.0401M7`.

The PR suggests to disable the failing validation when the major version is 7 or below.

The `retention_tag` keeps being read as `.` but the variable is only used in the validation. Major version, minor version, and revision are being passed to the metadata as `7`, `0`, and `0`, which seems reasonable.

### Validation

With the fix, the command
```
./readstat dummy_file.sas7bdat
```
shows the correct metadata.

The command
```
./readstat dummy_file.sas7bdat out.csv
```
also produces a CSV with a single row. But this row is actually intended to be soft-deleted. The only non-deleted row is at the very end of the file.

Without the fix, both commands fail on the release string validation.