### PR TITLE
Read all column info for empty SAS data files

### DIFF
--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -1404,7 +1404,7 @@ static readstat_error_t sas7bdat_parse_all_pages_pass2(sas7bdat_ctx_t *ctx) {
             }
             goto cleanup;
         }
-        if (ctx->parsed_row_count == ctx->row_limit)
+        if (ctx->row_limit > 0 && ctx->parsed_row_count == ctx->row_limit)
             break;
     }
 cleanup:

--- a/src/test/test_list.h
+++ b/src/test/test_list.h
@@ -674,6 +674,34 @@ static rt_test_group_t _test_groups[] = {
                         }
                     }
                 }
+            },
+
+            {
+                .label = "Empty SAS file with metadata spill-over beyond first page",
+                .test_formats = RT_FORMAT_SAS7BDAT,
+                .rows = 0,
+                .columns = {
+                    { .name = "one_of_many_long_column_names_1", .label = "Label for column 1", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_2", .label = "Label for column 2", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_3", .label = "Label for column 3", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_4", .label = "Label for column 4", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_5", .label = "Label for column 5", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_6", .label = "Label for column 6", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_7", .label = "Label for column 7", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_8", .label = "Label for column 8", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_9", .label = "Label for column 9", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_10", .label = "Label for column 10", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_11", .label = "Label for column 11", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_12", .label = "Label for column 12", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_13", .label = "Label for column 13", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_14", .label = "Label for column 14", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_15", .label = "Label for column 15", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_16", .label = "Label for column 16", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_17", .label = "Label for column 17", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_18", .label = "Label for column 18", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_19", .label = "Label for column 19", .format = "$CHAR8", .type = READSTAT_TYPE_STRING },
+                    { .name = "one_of_many_long_column_names_20", .label = "Label for column 20", .format = "$CHAR8", .type = READSTAT_TYPE_STRING }
+                }
             }
         }
     },

--- a/src/test/test_read.c
+++ b/src/test/test_read.c
@@ -191,6 +191,11 @@ static int handle_variable(int index, readstat_variable_t *variable,
             readstat_variable_get_name(variable),
             "Column names");
 
+    push_error_if_doubles_differ(rt_ctx,
+            readstat_type_class(column->type),
+            readstat_type_class(readstat_variable_get_type(variable)),
+            "Column type class");
+
     push_error_if_strings_differ(rt_ctx, column->label,
             readstat_variable_get_label(variable),
             "Column labels");

--- a/src/test/test_types.h
+++ b/src/test/test_types.h
@@ -1,7 +1,7 @@
 #include <time.h>
 
 #define RT_MAX_ROWS                 10
-#define RT_MAX_COLS                 10
+#define RT_MAX_COLS                 20
 #define RT_MAX_LABEL_SETS            2
 #define RT_MAX_NOTES                 2
 #define RT_MAX_STRING_REFS           3


### PR DESCRIPTION
This PR fixes a problem that I've observed with empty SAS data files that have a very high number (literally thousands) of columns.

An empty SAS data file can extend over multiple pages if the number of columns is high enough. When for such a file a column name header is on the second page or beyond, this header is currently not being read. The root cause is an early exit for the second pass that exits when the number of expected rows has been reached, which is always after the first page for empty data files.

In ReadStat the bug manifests itself in blank column names. Downstream in pyreadstat the bug produces errors due to column names with value `None` which pyreadstat isn't (and shouldn't be) prepared to handle.

