### PR TITLE
Bound SAS format suffix writes

### DIFF
--- a/src/sas/readstat_sas7bdat_read.c
+++ b/src/sas/readstat_sas7bdat_read.c
@@ -701,12 +701,13 @@ static readstat_variable_t *sas7bdat_init_variable(sas7bdat_ctx_t *ctx, int i,
         goto cleanup;
     }
     size_t len = strlen(variable->format);
-    if (ctx->col_info[i].format_width) {
-        len += snprintf(variable->format + len, sizeof(variable->format) - len,
+    if (ctx->col_info[i].format_width && len < sizeof(variable->format) - 1) {
+        snprintf(variable->format + len, sizeof(variable->format) - len,
                 "%d", ctx->col_info[i].format_width);
+        len = strlen(variable->format);
     }
-    if (len && ctx->col_info[i].format_digits) {
-        len += snprintf(variable->format + len, sizeof(variable->format) - len,
+    if (len && ctx->col_info[i].format_digits && len < sizeof(variable->format) - 1) {
+        snprintf(variable->format + len, sizeof(variable->format) - len,
                 ".%d", ctx->col_info[i].format_digits);
     }
     if ((retval = sas7bdat_copy_text_ref(variable->label, sizeof(variable->label), 


### PR DESCRIPTION
## Summary

- keep SAS format width and digit suffix writes inside `readstat_variable_t.format`
- recompute the stored length after a potentially truncated width before appending digits

## Root cause

`snprintf()` returns the number of bytes it wanted to write, even when the destination truncates the result. A near-full 256-byte format can therefore advance `len` past the array before the digit suffix is appended, producing an out-of-bounds pointer and an underflowed remaining size.

This fixes the publicly disclosed [OSV-2026-634](https://osv.dev/vulnerability/OSV-2026-634) / [OSS-Fuzz issue 506459940](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=506459940). The exact testcase previously reported `index 257 out of bounds for type char[256]` in `sas7bdat_init_variable()`.

## Verification

- `make check`: 4/4 tests passed under ASan/UBSan
- exact OSS-Fuzz testcase `5180794695122944` (SHA-256 `12128ef78252314bc605bc6c8236383caffff420be659e6b466b33dfb54e6136`): clean under ASan/UBSan after the fix
- all 96 generated SAS7BDAT corpus files: clean under ASan/UBSan
- `git diff --check`